### PR TITLE
Do not clone old world name (use new instead)

### DIFF
--- a/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonCloning.java
+++ b/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonCloning.java
@@ -15,8 +15,8 @@ import java.util.Map;
 
 public class SkeletonCloning {
 
-    public static SkeletonSlimeWorld fullClone(SlimeWorld world) {
-        return new SkeletonSlimeWorld(world.getName(),
+    public static SkeletonSlimeWorld fullClone(String worldName, SlimeWorld world) {
+        return new SkeletonSlimeWorld(worldName,
                 world.getLoader(),
                 cloneChunkStorage(world.getChunkStorage()),
                 world.getExtraData().clone(),

--- a/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonSlimeWorld.java
+++ b/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonSlimeWorld.java
@@ -94,15 +94,7 @@ public record SkeletonSlimeWorld(
             }
         }
 
-        SkeletonSlimeWorld clonedWorld = SkeletonCloning.fullClone(worldName, this);
-
-        if (loader != null) {
-            byte[] serializedWorld = SlimeSerializer.serialize(clonedWorld);
-
-            loader.saveWorld(worldName, serializedWorld);
-        }
-
-        return clonedWorld;
+        return SkeletonCloning.fullClone(worldName, this);
     }
 
 }

--- a/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonSlimeWorld.java
+++ b/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonSlimeWorld.java
@@ -4,16 +4,14 @@ import com.flowpowered.nbt.CompoundTag;
 import com.infernalsuite.aswm.ChunkPos;
 import com.infernalsuite.aswm.exceptions.WorldAlreadyExistsException;
 import com.infernalsuite.aswm.loaders.SlimeLoader;
-import com.infernalsuite.aswm.serialization.slime.SlimeSerializer;
 import com.infernalsuite.aswm.world.SlimeChunk;
 import com.infernalsuite.aswm.world.SlimeWorld;
 import com.infernalsuite.aswm.world.properties.SlimePropertyMap;
-import org.jetbrains.annotations.Nullable;
-
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import org.jetbrains.annotations.Nullable;
 
 public record SkeletonSlimeWorld(
         String name,

--- a/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonSlimeWorld.java
+++ b/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonSlimeWorld.java
@@ -7,11 +7,11 @@ import com.infernalsuite.aswm.loaders.SlimeLoader;
 import com.infernalsuite.aswm.world.SlimeChunk;
 import com.infernalsuite.aswm.world.SlimeWorld;
 import com.infernalsuite.aswm.world.properties.SlimePropertyMap;
+import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import org.jetbrains.annotations.Nullable;
 
 public record SkeletonSlimeWorld(
         String name,

--- a/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonSlimeWorld.java
+++ b/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonSlimeWorld.java
@@ -4,6 +4,7 @@ import com.flowpowered.nbt.CompoundTag;
 import com.infernalsuite.aswm.ChunkPos;
 import com.infernalsuite.aswm.exceptions.WorldAlreadyExistsException;
 import com.infernalsuite.aswm.loaders.SlimeLoader;
+import com.infernalsuite.aswm.serialization.slime.SlimeSerializer;
 import com.infernalsuite.aswm.world.SlimeChunk;
 import com.infernalsuite.aswm.world.SlimeWorld;
 import com.infernalsuite.aswm.world.properties.SlimePropertyMap;
@@ -93,7 +94,15 @@ public record SkeletonSlimeWorld(
             }
         }
 
-        return SkeletonCloning.fullClone(this);
+        SkeletonSlimeWorld clonedWorld = SkeletonCloning.fullClone(worldName, this);
+
+        if (loader != null) {
+            byte[] serializedWorld = SlimeSerializer.serialize(clonedWorld);
+
+            loader.saveWorld(worldName, serializedWorld);
+        }
+
+        return clonedWorld;
     }
 
 }

--- a/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonSlimeWorld.java
+++ b/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonSlimeWorld.java
@@ -8,6 +8,7 @@ import com.infernalsuite.aswm.world.SlimeChunk;
 import com.infernalsuite.aswm.world.SlimeWorld;
 import com.infernalsuite.aswm.world.properties.SlimePropertyMap;
 import org.jetbrains.annotations.Nullable;
+
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;


### PR DESCRIPTION
Fixes #7 

The new world name (from the cloned world) was not set in the SkeletonCloning#fullClone method, which caused the cloned world not to be loaded when cloned, but the original world.