### PR TITLE
Issue 24

### DIFF
--- a/core/src/main/java/com/infernalsuite/aswm/serialization/slime/SlimeSerializer.java
+++ b/core/src/main/java/com/infernalsuite/aswm/serialization/slime/SlimeSerializer.java
@@ -12,6 +12,7 @@ import com.infernalsuite.aswm.api.world.SlimeChunk;
 import com.infernalsuite.aswm.api.world.SlimeChunkSection;
 import com.infernalsuite.aswm.api.world.SlimeWorld;
 import com.infernalsuite.aswm.api.world.properties.SlimePropertyMap;
+import com.infernalsuite.aswm.skeleton.SlimeChunkSectionSkeleton;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -81,7 +82,7 @@ public class SlimeSerializer {
             outStream.writeInt(compressedEntitiesData.length);
             outStream.writeInt(entitiesData.length);
             outStream.write(compressedEntitiesData);
-            
+
             // Extra Tag
             {
                 byte[] extra = serializeCompoundTag(extraData);
@@ -128,6 +129,14 @@ public class SlimeSerializer {
 
             outStream.writeInt(sections.length);
             for (SlimeChunkSection slimeChunkSection : sections) {
+                if (slimeChunkSection == null) {
+                    slimeChunkSection = new SlimeChunkSectionSkeleton(
+                        new CompoundTag("", new CompoundMap()),
+                        new CompoundTag("", new CompoundMap()),
+                        null,
+                        null
+                    );
+                }
                 // Block Light
                 boolean hasBlockLight = slimeChunkSection.getBlockLight() != null;
                 outStream.writeBoolean(hasBlockLight);

--- a/patches/server/0003-fix-null-sections-from-lower-level-heights-depths.patch
+++ b/patches/server/0003-fix-null-sections-from-lower-level-heights-depths.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?G=C3=BCnther=20Jungbluth?= <gunther@gameslabs.net>
+Date: Mon, 9 Jan 2023 17:07:46 +0100
+Subject: [PATCH] fix: null sections, from lower level heights/depths
+
+
+diff --git a/src/main/java/com/infernalsuite/aswm/SimpleDataFixerConverter.java b/src/main/java/com/infernalsuite/aswm/SimpleDataFixerConverter.java
+index e3b253fda8e12ef165fc55f42aefcc91f0a46b5e..ca045e00a592b2e5707639ba62d9461b563764ba 100644
+--- a/src/main/java/com/infernalsuite/aswm/SimpleDataFixerConverter.java
++++ b/src/main/java/com/infernalsuite/aswm/SimpleDataFixerConverter.java
+@@ -3,6 +3,7 @@ package com.infernalsuite.aswm;
+ import ca.spottedleaf.dataconverter.minecraft.datatypes.MCTypeRegistry;
+ import ca.spottedleaf.dataconverter.minecraft.walkers.generic.WalkerUtils;
+ import ca.spottedleaf.dataconverter.types.nbt.NBTMapType;
++import com.flowpowered.nbt.CompoundMap;
+ import com.flowpowered.nbt.CompoundTag;
+ import com.infernalsuite.aswm.serialization.SlimeWorldReader;
+ import com.infernalsuite.aswm.skeleton.SkeletonSlimeWorld;
+@@ -50,6 +51,16 @@ class SimpleDataFixerConverter implements SlimeWorldReader<SlimeWorld> {
+             for (int i = 0; i < sections.length; i++) {
+                 SlimeChunkSection dataSection = chunk.getSections()[i];
+ 
++                if (dataSection == null) {
++                    sections[i] = chunk.getSections()[i] = new SlimeChunkSectionSkeleton(
++                        new CompoundTag("", new CompoundMap()),
++                        new CompoundTag("", new CompoundMap()),
++                        null,
++                        null
++                    );
++                    continue;
++                }
++
+                 com.flowpowered.nbt.CompoundTag blockStateTag = blockStateTag = convertAndBack(dataSection.getBlockStatesTag(), (tag) -> {
+                     WalkerUtils.convertList(MCTypeRegistry.BLOCK_STATE, new NBTMapType(tag), "palette", currentVersion, newVersion);
+                 });

--- a/plugin/src/main/java/com/grinderwolf/swm/plugin/SWMPlugin.java
+++ b/plugin/src/main/java/com/grinderwolf/swm/plugin/SWMPlugin.java
@@ -7,6 +7,7 @@ import com.grinderwolf.swm.plugin.commands.CommandManager;
 import com.grinderwolf.swm.plugin.config.ConfigManager;
 import com.grinderwolf.swm.plugin.config.WorldData;
 import com.grinderwolf.swm.plugin.config.WorldsConfig;
+import com.grinderwolf.swm.plugin.listeners.WorldUnlocker;
 import com.grinderwolf.swm.plugin.loaders.LoaderUtils;
 import com.grinderwolf.swm.plugin.log.Logging;
 import com.infernalsuite.aswm.api.SlimeNMSBridge;
@@ -134,7 +135,7 @@ public class SWMPlugin extends JavaPlugin implements SlimePlugin, Listener {
                 .forEach(this::loadWorld);
 
         this.getServer().getPluginManager().registerEvents(this, this);
-
+        this.getServer().getPluginManager().registerEvents(new WorldUnlocker(), this);
         //loadedWorlds.clear // - Commented out because not sure why this would be cleared. Needs checking
     }
 

--- a/plugin/src/main/java/com/grinderwolf/swm/plugin/listeners/WorldUnlocker.java
+++ b/plugin/src/main/java/com/grinderwolf/swm/plugin/listeners/WorldUnlocker.java
@@ -1,0 +1,41 @@
+package com.grinderwolf.swm.plugin.listeners;
+
+import com.grinderwolf.swm.plugin.SWMPlugin;
+import com.grinderwolf.swm.plugin.log.Logging;
+import com.infernalsuite.aswm.api.SlimeNMSBridge;
+import com.infernalsuite.aswm.api.exceptions.UnknownWorldException;
+import com.infernalsuite.aswm.api.world.SlimeWorld;
+import com.infernalsuite.aswm.api.world.SlimeWorldInstance;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.world.WorldUnloadEvent;
+
+import java.io.IOException;
+
+public class WorldUnlocker implements Listener {
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onWorldUnload(WorldUnloadEvent event) {
+        SlimeWorldInstance world = SlimeNMSBridge.instance().getInstance(event.getWorld());
+
+        if (world != null) {
+            Bukkit.getScheduler().runTaskAsynchronously(SWMPlugin.getInstance(), () -> unlockWorld(world.getSlimeWorldMirror()));
+        }
+    }
+
+    private void unlockWorld(SlimeWorld world) {
+        try {
+            if (world.getLoader() != null) {
+                world.getLoader().unlockWorld(world.getName());
+            }
+        } catch (IOException ex) {
+            Logging.error("Failed to unlock world " + world.getName() + ". Retrying in 5 seconds. Stack trace:");
+            ex.printStackTrace();
+
+            Bukkit.getScheduler().runTaskLaterAsynchronously(SWMPlugin.getInstance(), () -> unlockWorld(world), 100);
+        } catch (UnknownWorldException e) {
+        }
+    }
+}


### PR DESCRIPTION
When converting a world from a different height/chunk section length, some chunk sections are null.
This temporarily (could be part of the world conversion algorithm) fixes nulled slime chunks #24 