### PR TITLE
Acquire lock when loading world

### DIFF
--- a/plugin/src/main/java/com/grinderwolf/swm/plugin/SWMPlugin.java
+++ b/plugin/src/main/java/com/grinderwolf/swm/plugin/SWMPlugin.java
@@ -316,6 +316,15 @@ public class SWMPlugin extends JavaPlugin implements SlimePlugin, Listener {
         SlimeWorld mirror = instance.getSlimeWorldMirror();
         Bukkit.getPluginManager().callEvent(new LoadSlimeWorldEvent(mirror));
         registerWorld(mirror);
+
+        if (!slimeWorld.isReadOnly() && slimeWorld.getLoader() != null) {
+            try {
+                slimeWorld.getLoader().acquireLock(slimeWorld.getName());
+            } catch (UnknownWorldException | WorldLockedException | IOException e) {
+                e.printStackTrace();
+            }
+        }
+
         return mirror;
     }
 


### PR DESCRIPTION
Currently when loading world from its clone is missing the lock.
