### PR TITLE
RedisLoader rewrite

### DIFF
--- a/plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/redis/RedisLoader.java
+++ b/plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/redis/RedisLoader.java
@@ -5,18 +5,19 @@ import com.infernalsuite.aswm.api.exceptions.WorldLockedException;
 import com.infernalsuite.aswm.api.loaders.SlimeLoader;
 import com.grinderwolf.swm.plugin.config.DatasourcesConfig;
 import com.grinderwolf.swm.plugin.loaders.redis.util.StringByteCodec;
-import io.lettuce.core.RedisClient;
+import io.lettuce.core.*;
 import io.lettuce.core.api.sync.RedisCommands;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 public class RedisLoader implements SlimeLoader {
 
-    private static final String WORLD_DATA_PREFIX = "aswm_world_data_";
-    private static final String WORLD_LOCK_PREFIX = "aswm_world_lock_";
+    private static final String WORLD_DATA_PREFIX = "aswm:world:data:";
+    private static final String WORLD_LOCK_PREFIX = "aswm:world:lock:";
+    private static final String WORLD_LIST_PREFIX = "aswm:world:list";
     private static final byte TRUE = 0x1;
-    private static final byte FALSE = 0x0;
 
     public RedisLoader(DatasourcesConfig.RedisConfig config) {
         this.connection = RedisClient
@@ -38,52 +39,54 @@ public class RedisLoader implements SlimeLoader {
 
     @Override
     public boolean worldExists(String name) throws IOException {
-        return connection.get(WORLD_LOCK_PREFIX  + name) != null;
+        return connection.exists(WORLD_DATA_PREFIX + name) == 1;
     }
 
     @Override
     public List<String> listWorlds() throws IOException {
-        return connection.keys(WORLD_LOCK_PREFIX  + "*");
+        return connection.smembers(WORLD_LIST_PREFIX)
+                .stream()
+                .map(bytes -> new String(bytes, StandardCharsets.UTF_8))
+                .toList();
     }
 
     @Override
     public void saveWorld(String name, byte[] bytes) throws IOException {
         connection.set(WORLD_DATA_PREFIX + name, bytes);
+
+        // Also add to the world list set. We can't do this in one atomic operation (mset) because it's a set add
+        connection.sadd(WORLD_LIST_PREFIX, name.getBytes(StandardCharsets.UTF_8));
     }
 
     @Override
     public void deleteWorld(String name) throws UnknownWorldException, IOException {
-        boolean exists = this.worldExists(name);
-        if (!exists) {
+        long deletedCount = connection.del(WORLD_DATA_PREFIX + name, WORLD_LOCK_PREFIX + name);
+
+        // We're checking equal to zero, because the lock key doesn't have to exist
+        if (deletedCount == 0) {
             throw new UnknownWorldException(name);
         }
-        connection.del(WORLD_DATA_PREFIX + name, WORLD_LOCK_PREFIX + name);
+
+        // Remove the world from the world list set
+        connection.srem(WORLD_LIST_PREFIX, name.getBytes(StandardCharsets.UTF_8));
     }
 
     @Override
     public void acquireLock(String worldName) throws UnknownWorldException, WorldLockedException, IOException {
-        if (this.isWorldLocked(worldName)) {
+        boolean wasSet = connection.setnx(WORLD_LOCK_PREFIX + worldName, new byte[]{TRUE});
+        if (!wasSet) {
+            // The key already exists, so the setnx returned 0 (false)
             throw new WorldLockedException(worldName);
         }
-
-        connection.set(WORLD_LOCK_PREFIX + worldName, new byte[]{TRUE});
     }
 
     @Override
     public boolean isWorldLocked(String worldName) throws UnknownWorldException, IOException {
-        byte[] lock = connection.get(WORLD_LOCK_PREFIX + worldName);
-        if (lock == null) {
-            throw new UnknownWorldException(worldName);
-        }
-        if (lock[0] == TRUE) {
-            return true;
-        }
-
-        return false;
+        return connection.exists(WORLD_LOCK_PREFIX + worldName) == 1;
     }
 
     @Override
     public void unlockWorld(String worldName) throws UnknownWorldException, IOException {
-        connection.set(WORLD_LOCK_PREFIX + worldName, new byte[]{FALSE});
+        connection.del(WORLD_LOCK_PREFIX + worldName);
     }
 }

--- a/plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/redis/RedisLoader.java
+++ b/plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/redis/RedisLoader.java
@@ -33,6 +33,7 @@ public class RedisLoader implements SlimeLoader {
     private static final byte TRUE = 0x1;
 
     private final Map<String, ScheduledFuture<?>> lockedWorlds = new HashMap<>();
+    private final RedisCommands<String, byte[]> connection;
 
     public RedisLoader(DatasourcesConfig.RedisConfig config) {
         this.connection = RedisClient
@@ -40,8 +41,6 @@ public class RedisLoader implements SlimeLoader {
             .connect(StringByteCodec.INSTANCE)
             .sync();
     }
-
-    private final RedisCommands<String, byte[]> connection;
 
     @Override
     public byte[] loadWorld(String name) throws UnknownWorldException, IOException {

--- a/plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/redis/RedisLoader.java
+++ b/plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/redis/RedisLoader.java
@@ -19,6 +19,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 public class RedisLoader implements SlimeLoader {
 
@@ -61,7 +62,7 @@ public class RedisLoader implements SlimeLoader {
         return connection.smembers(WORLD_LIST_PREFIX)
                 .stream()
                 .map(bytes -> new String(bytes, StandardCharsets.UTF_8))
-                .toList();
+                .collect(Collectors.toList()); // We can't use .toList because this needs to be mutable.
     }
 
     @Override


### PR DESCRIPTION
Hello!

I have made major improvements to the Redis loader it is now up-to-speed feature wise with the other loaders.

This PR does make breaking changes for people currently using the Redis loader. However, there were a number of logic issues in the current implementation that would've made it not very useful (if you could get it working at all):
- It was possible to get a world into a deadlock, as the lock was setting a permanent key with no expiry. So killing the server or getting the code into a state where it never removed the lock would cause a deadlock.
- Listing of worlds ran a keys over all of the lock keys, and returned them directly. A lock doesn't have to exist on a world, so it would not be able to find all of them, and doing this also means that the world names would be incorrect (they would contain the key prefix)
- World exists method was based on the lock key existence, same problem as above - and would for example stop you from deleting a world, or anything that used .isWorldLocked
- Using a redis.keys() is bad practice on production machines. It blocks the whole redis instance and searches through every single key. This means you're dealing with O(n) where n is the size of the entire redis instance. If you're storing other data on there, that gets really big!

So, to solve all of these problems, I have made the following changes & tested them:
- Added in a Redis set key for the world list. Now, querying the list of worlds is only O(n) where n is the number of worlds that exist, rather than the number of keys in Redis. This is significantly faster
- I have turned many operations atomic where possible, reducing the number of total redis roundtrips. Examples of this are using `setnx`, `del` calls handling retun count values, etc.
- I have changed the locks to use an expiry system, similar to how the Mongo implementation implements it. Deadlock is no longer possible. The lock state is based on the existence of the key, not the value of the key, which is the more redis-friendly way, and let's us use Redis' native expiry system.
- I have made optimisations to the rest of the redis commands. For example, checking a world exists is now a redis `.exists` call rather than fetching all the data back and checking it, many commands that can be merged into one command have been (such as multi set or delete).
- All complys with modern Redis standards, and doing it the redis way :)

