### PR TITLE
Check plugin is null before getting it's name

### DIFF
--- a/patches/api/0002-Dont-close-Slime-Plugin-Classloader.patch
+++ b/patches/api/0002-Dont-close-Slime-Plugin-Classloader.patch
@@ -12,7 +12,7 @@ index 86771934c76dd63b219069b045dbb5511ee0f45d..f582456d85e5f5caae0a8dad26aa8e0e
              // Paper end
              super.close();
          } finally {
-+            if (!this.plugin.getName().equals("SlimeWorldManager")) { // ASWM - Don't close
++            if (this.plugin == null || !this.plugin.getName().equals("SlimeWorldManager")) { // ASWM - Don't close
              jar.close();
 +            } // ASWM - Don't close
          }


### PR DESCRIPTION
It was noticed that when plugins are reloaded, for example with plugman, that this.plugin would be null and it would fail. 
To solve this, check the plugin is null first.