### PR TITLE
Use supplied loader when cloning worlds

### DIFF
--- a/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonCloning.java
+++ b/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonCloning.java
@@ -2,6 +2,7 @@ package com.infernalsuite.aswm.skeleton;
 
 import com.flowpowered.nbt.CompoundTag;
 import com.infernalsuite.aswm.ChunkPos;
+import com.infernalsuite.aswm.api.loaders.SlimeLoader;
 import com.infernalsuite.aswm.api.utils.NibbleArray;
 import com.infernalsuite.aswm.api.world.SlimeChunk;
 import com.infernalsuite.aswm.api.world.SlimeChunkSection;
@@ -15,9 +16,9 @@ import java.util.Map;
 
 public class SkeletonCloning {
 
-    public static SkeletonSlimeWorld fullClone(String worldName, SlimeWorld world) {
+    public static SkeletonSlimeWorld fullClone(String worldName, SlimeWorld world, SlimeLoader loader) {
         return new SkeletonSlimeWorld(worldName,
-                world.getLoader(),
+                loader == null ? world.getLoader() : loader,
                 world.isReadOnly(),
                 cloneChunkStorage(world.getChunkStorage()),
                 world.getExtraData().clone(),

--- a/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonSlimeWorld.java
+++ b/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonSlimeWorld.java
@@ -8,7 +8,6 @@ import com.infernalsuite.aswm.api.world.SlimeChunk;
 import com.infernalsuite.aswm.api.world.SlimeWorld;
 import com.infernalsuite.aswm.api.world.properties.SlimePropertyMap;
 import com.infernalsuite.aswm.serialization.slime.SlimeSerializer;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
@@ -95,7 +94,7 @@ public record SkeletonSlimeWorld(
             }
         }
 
-        SlimeWorld cloned = SkeletonCloning.fullClone(worldName, this);
+        SlimeWorld cloned = SkeletonCloning.fullClone(worldName, this, loader);
         if (loader != null) {
             loader.saveWorld(worldName, SlimeSerializer.serialize(cloned));
         }

--- a/patches/server/0002-Slime-World-Manager.patch
+++ b/patches/server/0002-Slime-World-Manager.patch
@@ -1499,7 +1499,7 @@ index 0000000000000000000000000000000000000000..9bc04bc3215c088a799219551b53f13f
 +            }
 +        }
 +
-+        SlimeWorld cloned = SkeletonCloning.fullClone(worldName, this);
++        SlimeWorld cloned = SkeletonCloning.fullClone(worldName, this, loader);
 +        if (loader != null) {
 +            loader.saveWorld(worldName, SlimeSerializer.serialize(cloned));
 +        }


### PR DESCRIPTION
Cloning a world from file to db would save the cloned world to db and then on shutdown it would also save the in-memory world to file since that was the loader of the world which was cloned. 

Instead set the loader to the one supplied to the clone method