### PR TITLE
fix(slimeserializer): null chunk sections

### DIFF
--- a/core/src/main/java/com/infernalsuite/aswm/serialization/slime/SlimeSerializer.java
+++ b/core/src/main/java/com/infernalsuite/aswm/serialization/slime/SlimeSerializer.java
@@ -17,10 +17,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteOrder;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 public class SlimeSerializer {
 
@@ -124,7 +121,7 @@ public class SlimeSerializer {
             outStream.write(heightMaps);
 
             // Chunk sections
-            SlimeChunkSection[] sections = chunk.getSections();
+            SlimeChunkSection[] sections = Arrays.stream(chunk.getSections()).filter(Objects::nonNull).toList().toArray(new SlimeChunkSection[0]);
 
             outStream.writeInt(sections.length);
             for (SlimeChunkSection slimeChunkSection : sections) {


### PR DESCRIPTION
Fixing issue when chunksection is null in some worlds. And fill these null chunksections with SlimeChunkSection[0] to avoid this error and crash the whole import.

```
[18:02:16 WARN]: java.lang.RuntimeException: java.lang.NullPointerException: Cannot invoke "com.infernalsuite.aswm.api.world.SlimeChunkSection.getBlockLight()" because "slimeChunkSection" is null
[18:02:16 WARN]:        at com.infernalsuite.aswm.serialization.slime.SlimeSerializer.serialize(SlimeSerializer.java:96)
[18:02:16 WARN]:        at BuildPlugin.jar//com.infernalsuite.aswm.importer.SWMImporter.main(SWMImporter.java:48)
[18:02:16 WARN]:        at BuildPlugin.jar//sg.buildplugin.WorldManager$1.run(WorldManager.java:137)
[18:02:16 WARN]:        at org.bukkit.craftbukkit.v1_19_R3.scheduler.CraftTask.run(CraftTask.java:101)
[18:02:16 WARN]:        at org.bukkit.craftbukkit.v1_19_R3.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:57)
[18:02:16 WARN]:        at com.destroystokyo.paper.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:22)
[18:02:16 WARN]:        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[18:02:16 WARN]:        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[18:02:16 WARN]:        at java.base/java.lang.Thread.run(Thread.java:833)
[18:02:16 WARN]: Caused by: java.lang.NullPointerException: Cannot invoke "com.infernalsuite.aswm.api.world.SlimeChunkSection.getBlockLight()" because "slimeChunkSection" is null
[18:02:16 WARN]:        at com.infernalsuite.aswm.serialization.slime.SlimeSerializer.serializeChunks(SlimeSerializer.java:132)
[18:02:16 WARN]:        at com.infernalsuite.aswm.serialization.slime.SlimeSerializer.serialize(SlimeSerializer.java:50)
[18:02:16 WARN]:        ... 8 more
```
