### PR TITLE
Acquire lock before loading the world and throw errors accordingly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ build/
 slimeworldmanager-api
 slimeworldmanager-server
 run
+**/bin

--- a/api/src/main/java/com/infernalsuite/aswm/api/SlimePlugin.java
+++ b/api/src/main/java/com/infernalsuite/aswm/api/SlimePlugin.java
@@ -81,7 +81,7 @@ public interface SlimePlugin {
      * @param world {@link SlimeWorld} world to be added to the server's world list
      * @return Returns a slime world representing a live minecraft world
      */
-    SlimeWorld loadWorld(SlimeWorld world);
+    SlimeWorld loadWorld(SlimeWorld world) throws UnknownWorldException, WorldLockedException, IOException;
 
     /**
      * Migrates a {@link SlimeWorld} to another datasource.

--- a/plugin/src/main/java/com/grinderwolf/swm/plugin/commands/sub/CloneWorldCmd.java
+++ b/plugin/src/main/java/com/grinderwolf/swm/plugin/commands/sub/CloneWorldCmd.java
@@ -105,7 +105,7 @@ public class CloneWorldCmd implements Subcommand {
 
                             config.getWorlds().put(worldName, worldData);
                             config.save();
-                        } catch (IllegalArgumentException ex) {
+                        } catch (Exception ex) {
                             sender.sendMessage(Logging.COMMAND_PREFIX + ChatColor.RED + "Failed to generate world " + worldName + ": " + ex.getMessage() + ".");
 
                             return;

--- a/plugin/src/main/java/com/grinderwolf/swm/plugin/commands/sub/CreateWorldCmd.java
+++ b/plugin/src/main/java/com/grinderwolf/swm/plugin/commands/sub/CreateWorldCmd.java
@@ -106,7 +106,7 @@ public class CreateWorldCmd implements Subcommand {
 
                             sender.sendMessage(Logging.COMMAND_PREFIX + ChatColor.GREEN + "World " + ChatColor.YELLOW + worldName
                                     + ChatColor.GREEN + " created in " + (System.currentTimeMillis() - start) + "ms!");
-                        } catch (IllegalArgumentException ex) {
+                        } catch (Exception ex) {
                             sender.sendMessage(Logging.COMMAND_PREFIX + ChatColor.RED + "Failed to create world " + worldName + ": " + ex.getMessage() + ".");
                         }
                     });

--- a/plugin/src/main/java/com/grinderwolf/swm/plugin/commands/sub/LoadTemplateWorldCmd.java
+++ b/plugin/src/main/java/com/grinderwolf/swm/plugin/commands/sub/LoadTemplateWorldCmd.java
@@ -94,7 +94,7 @@ public class LoadTemplateWorldCmd implements Subcommand {
                     Bukkit.getScheduler().runTask(SWMPlugin.getInstance(), () -> {
                         try {
                             SWMPlugin.getInstance().loadWorld(slimeWorld);
-                        } catch (IllegalArgumentException ex) {
+                        } catch (Exception ex) {
                             sender.sendMessage(Logging.COMMAND_PREFIX + ChatColor.RED + "Failed to generate world " + worldName + ": " + ex.getMessage() + ".");
 
                             return;

--- a/plugin/src/main/java/com/grinderwolf/swm/plugin/commands/sub/LoadWorldCmd.java
+++ b/plugin/src/main/java/com/grinderwolf/swm/plugin/commands/sub/LoadWorldCmd.java
@@ -87,7 +87,7 @@ public class LoadWorldCmd implements Subcommand {
                     Bukkit.getScheduler().runTask(SWMPlugin.getInstance(), () -> {
                         try {
                             SWMPlugin.getInstance().loadWorld(slimeWorld);
-                        } catch (IllegalArgumentException ex) {
+                        } catch (Exception ex) {
                             sender.sendMessage(Logging.COMMAND_PREFIX + ChatColor.RED + "Failed to generate world " + worldName + ": " + ex.getMessage() + ".");
 
                             return;


### PR DESCRIPTION
Loading a world which isn't `readOnly` should first acquire the lock before actually loading it, throw errors accordingly of the `acquireLock` result