### PR TITLE
Rebuild patches in paper_upstream

### DIFF
--- a/patches/api/0001-Slime-World-Manager.patch
+++ b/patches/api/0001-Slime-World-Manager.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Slime World Manager
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 4b2330bac734cd07f8798ceeb6d9c67bd3f3521d..08e27f05e93d26a51ce8f0fe9597b0d844aa1648 100644
+index 149f9088fe806467656e8b1c4157df60fda69ba7..a26394451c94003317997c9167d3e2404bc88d9d 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -1,3 +1,5 @@
@@ -14,7 +14,7 @@ index 4b2330bac734cd07f8798ceeb6d9c67bd3f3521d..08e27f05e93d26a51ce8f0fe9597b0d8
  plugins {
      `java-library`
      `maven-publish`
-@@ -25,6 +27,7 @@ val annotationsVersion = "24.0.1"
+@@ -27,6 +29,7 @@ val annotationsVersion = "24.0.1"
  
  dependencies {
      // api dependencies are listed transitively to API consumers

--- a/patches/server/0001-Build-Changes.patch
+++ b/patches/server/0001-Build-Changes.patch
@@ -5,11 +5,11 @@ Subject: [PATCH] Build Changes
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index a3a76b9b7efa773117d2ee1ce53ef784b09b277d..04adcb284a24aac15697283967a476563130aee8 100644
+index 57f2c414dbfe127c193002fbc8eeb22e94e9cb55..0c100bde0429da6744e685f2784cfa85e2e078f1 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -7,8 +7,14 @@ plugins {
- }
+@@ -13,8 +13,14 @@ configurations.named(log4jPlugins.compileClasspathConfigurationName) {
+ val alsoShade: Configuration by configurations.creating
  
  dependencies {
 -    implementation(project(":paper-api"))
@@ -25,7 +25,7 @@ index a3a76b9b7efa773117d2ee1ce53ef784b09b277d..04adcb284a24aac15697283967a47656
      // Paper start
      implementation("org.jline:jline-terminal-jansi:3.21.0")
      implementation("net.minecrell:terminalconsoleappender:1.3.0")
-@@ -62,7 +68,7 @@ tasks.jar {
+@@ -72,7 +78,7 @@ tasks.jar {
          attributes(
              "Main-Class" to "org.bukkit.craftbukkit.Main",
              "Implementation-Title" to "CraftBukkit",
@@ -34,7 +34,7 @@ index a3a76b9b7efa773117d2ee1ce53ef784b09b277d..04adcb284a24aac15697283967a47656
              "Implementation-Vendor" to date, // Paper
              "Specification-Title" to "Bukkit",
              "Specification-Version" to project.version,
-@@ -134,7 +140,7 @@ fun TaskContainer.registerRunTask(
+@@ -149,7 +155,7 @@ fun TaskContainer.registerRunTask(
      name: String,
      block: JavaExec.() -> Unit
  ): TaskProvider<JavaExec> = register<JavaExec>(name) {
@@ -1985,10 +1985,10 @@ index ce449b7b6f615f2c8240e4207f06d4e54ae0083e..a94e41a2315c17fb7c387efd9ee5db7f
      public FullChunkStatus status;
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index fb82bb52f219e7683fe1d3c0fb3acbe2251de8d4..b752bd3963d78963532c308df66161175fd9f84b 100644
+index 3238cbcba567b1242c77e41f6b6f19a8d157fb4e..c5bfa7fffa1e7cbddf6d151f98ce92ef8ac4505f 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -274,7 +274,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -272,7 +272,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
      private final PackRepository packRepository;
      private final ServerScoreboard scoreboard;
      @Nullable
@@ -1997,7 +1997,7 @@ index fb82bb52f219e7683fe1d3c0fb3acbe2251de8d4..b752bd3963d78963532c308df6616117
      private final CustomBossEvents customBossEvents;
      private final ServerFunctionManager functionManager;
      private final FrameTimer frameTimer;
-@@ -455,60 +455,75 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -453,60 +453,75 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          LevelStorageSource.LevelStorageAccess worldSession = this.storageSource;
  
          Registry<LevelStem> dimensions = this.registries.compositeAccess().registryOrThrow(Registries.LEVEL_STEM);
@@ -2089,7 +2089,7 @@ index fb82bb52f219e7683fe1d3c0fb3acbe2251de8d4..b752bd3963d78963532c308df6616117
                          MinecraftServer.LOGGER.warn("Could not create path for " + newWorld + "!");
                          MinecraftServer.LOGGER.info("---- Migration of old " + worldType + " folder failed ----");
                      }
-@@ -516,7 +531,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -514,7 +529,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
                  try {
                      worldSession = LevelStorageSource.createDefault(this.server.getWorldContainer().toPath()).validateAndCreateAccess(name, dimensionKey);
@@ -2098,7 +2098,7 @@ index fb82bb52f219e7683fe1d3c0fb3acbe2251de8d4..b752bd3963d78963532c308df6616117
                      throw new RuntimeException(ex);
                  }
              }
-@@ -530,18 +545,18 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -528,18 +543,18 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              DynamicOps<Tag> dynamicops = RegistryOps.create(NbtOps.INSTANCE, (HolderLookup.Provider) worldloader_a.datapackWorldgen());
              Pair<WorldData, WorldDimensions.Complete> pair = worldSession.getDataTag(dynamicops, worldloader_a.dataConfiguration(), iregistry, worldloader_a.datapackWorldgen().allRegistriesLifecycle());
  
@@ -2121,7 +2121,7 @@ index fb82bb52f219e7683fe1d3c0fb3acbe2251de8d4..b752bd3963d78963532c308df6616117
                      DedicatedServerProperties dedicatedserverproperties = ((DedicatedServer) this).getProperties();
  
                      worldsettings = new LevelSettings(dedicatedserverproperties.levelName, dedicatedserverproperties.gamemode, dedicatedserverproperties.hardcore, dedicatedserverproperties.difficulty, false, new GameRules(), worldloader_a.dataConfiguration());
-@@ -566,20 +581,20 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -564,20 +579,20 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              LevelStem worlddimension = (LevelStem) dimensions.get(dimensionKey);
  
              org.bukkit.generator.WorldInfo worldInfo = new org.bukkit.craftbukkit.generator.CraftWorldInfo(iworlddataserver, worldSession, org.bukkit.World.Environment.getEnvironment(dimension), worlddimension.type().value(), worlddimension.generator(), this.registryAccess()); // Paper
@@ -2146,7 +2146,7 @@ index fb82bb52f219e7683fe1d3c0fb3acbe2251de8d4..b752bd3963d78963532c308df6616117
                  this.worldData = worlddata;
                  this.worldData.setGameType(((DedicatedServer) this).getProperties().gamemode); // From DedicatedServer.init
  
-@@ -590,13 +605,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -588,13 +603,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  this.readScoreboard(worldpersistentdata);
                  this.server.scoreboardManager = new org.bukkit.craftbukkit.scoreboard.CraftScoreboardManager(this, world.getScoreboard());
                  this.commandStorage = new CommandStorage(worldpersistentdata);
@@ -2163,7 +2163,7 @@ index fb82bb52f219e7683fe1d3c0fb3acbe2251de8d4..b752bd3963d78963532c308df6616117
                      spawners = Collections.emptyList();
                  }
                  world = new ServerLevel(this, this.executor, worldSession, iworlddataserver, worldKey, worlddimension, worldloadlistener, flag, j, spawners, true, this.overworld().getRandomSequences(), org.bukkit.World.Environment.getEnvironment(dimension), gen, biomeProvider);
-@@ -610,12 +625,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -608,12 +623,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              // Paper - move up
              this.getPlayerList().addWorldborderListener(world);
  
@@ -2178,7 +2178,7 @@ index fb82bb52f219e7683fe1d3c0fb3acbe2251de8d4..b752bd3963d78963532c308df6616117
              this.prepareLevels(worldserver.getChunkSource().chunkMap.progressListener, worldserver);
              //worldserver.entityManager.tick(); // SPIGOT-6526: Load pending entities so they are available to the API // Paper - rewrite chunk system, not required to "tick" anything
              this.server.getPluginManager().callEvent(new org.bukkit.event.world.WorldLoadEvent(worldserver.getWorld()));
-@@ -624,11 +639,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -622,11 +637,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          // Paper start - Handle collideRule team for player collision toggle
          final ServerScoreboard scoreboard = this.getScoreboard();
          final java.util.Collection<String> toRemove = scoreboard.getPlayerTeams().stream().filter(team -> team.getName().startsWith("collideRule_")).map(net.minecraft.world.scores.PlayerTeam::getName).collect(java.util.stream.Collectors.toList());
@@ -2192,7 +2192,7 @@ index fb82bb52f219e7683fe1d3c0fb3acbe2251de8d4..b752bd3963d78963532c308df6616117
              this.getPlayerList().collideRuleTeamName = org.apache.commons.lang3.StringUtils.left("collideRule_" + java.util.concurrent.ThreadLocalRandom.current().nextInt(), 16);
              net.minecraft.world.scores.PlayerTeam collideTeam = scoreboard.addPlayerTeam(this.getPlayerList().collideRuleTeamName);
              collideTeam.setSeeFriendlyInvisibles(false); // Because we want to mimic them not being on a team at all
-@@ -1681,7 +1696,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1693,7 +1708,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      @DontObfuscate
      public String getServerModName() {
@@ -2318,10 +2318,10 @@ index 9c6a2884c34a9f6e775103da42480cd6b8c693b3..3ef732bd50239c547eddfd0dcbc053a7
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ffa27c9c02dc4d12411fc089de3af8e8e12ba06e..d159eaa78bf6d452d3938928ec8a3f5189caae09 100644
+index a05c1bc8874ef5e380544a6a344c848e37da49c4..b40755e2ca859bef3b686f11e4d239092786755f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -262,7 +262,7 @@ import javax.annotation.Nullable; // Paper
+@@ -264,7 +264,7 @@ import javax.annotation.Nullable; // Paper
  import javax.annotation.Nonnull; // Paper
  
  public final class CraftServer implements Server {


### PR DESCRIPTION
Compiling the paper_upstream branch (from a fresh git clone) is sort of hit or miss. Sometimes it works, sometimes it doesn't.
It fails at applying patches for net.minecraft.server.MinecraftServer (in the 0001 Build Changes Patch)

In one of the few times I got it to work, I decided to rebuild the patches, and it works flawlessly now. 

If you're asking why CI builds the branch just fine, I would assume It's because the CIs copy of the repo has more git history to work with. (I'd assume this because I got it to compile every time if I base it off an ancient commit and then slowly update the repository and applyPatches over and over again) 

