### PR TITLE
Bump bukkit API version and some improvements in upgrading

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
     api("com.flowpowered:flow-nbt:2.0.2")
     api("org.jetbrains:annotations:23.0.0")
 
-    compileOnly("io.papermc.paper:paper-api:1.20-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:$version")
 }
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,11 @@
 group=com.infernalsuite.aswm
-version=1.20-R0.1-SNAPSHOT
 
+## Bump those two properties if you are upgrading plugin to a new mc version
+# Bukkit API Version
+version=1.20.1-R0.1-SNAPSHOT
+# Minecraft Version
 mcVersion=1.20.1
+
 paperRef=7145f41b6ebe89d79f39826663c99f33d7756669
 
 org.gradle.caching=true

--- a/patches/api/0001-Slime-World-Manager.patch
+++ b/patches/api/0001-Slime-World-Manager.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Slime World Manager
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 149f9088fe806467656e8b1c4157df60fda69ba7..a26394451c94003317997c9167d3e2404bc88d9d 100644
+index 8045f92ffdfb4164bcbef99c41359590c45f9006..336fd41102f8fbb8ddd3399042a1c3b1bdc78c72 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -1,3 +1,5 @@
@@ -14,11 +14,11 @@ index 149f9088fe806467656e8b1c4157df60fda69ba7..a26394451c94003317997c9167d3e240
  plugins {
      `java-library`
      `maven-publish`
-@@ -27,6 +29,7 @@ val annotationsVersion = "24.0.1"
+@@ -27,6 +29,7 @@ configurations.api {
  
  dependencies {
      // api dependencies are listed transitively to API consumers
 +    api(project(":api")) // ASWM
      api("com.google.guava:guava:31.1-jre")
      api("com.google.code.gson:gson:2.10")
-     api("net.md-5:bungeecord-chat:1.16-R0.4-deprecated+build.9") // Paper
+     api("net.md-5:bungeecord-chat:$bungeeCordChatVersion-deprecated+build.14") // Paper

--- a/patches/server/0001-Build-Changes.patch
+++ b/patches/server/0001-Build-Changes.patch
@@ -1968,7 +1968,7 @@ index 7e8dc9e8f381abfdcce2746edc93122d623622d1..12aadf4c981cdb1a6405de99016f4b40
      public FullChunkStatus status;
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 3238cbcba567b1242c77e41f6b6f19a8d157fb4e..c5bfa7fffa1e7cbddf6d151f98ce92ef8ac4505f 100644
+index 67ee3a4ca8a6cdeb275653d492a1fea8037c51fb..a289d476ea9ca797efbe9f40437a2cbc607b2d04 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -272,7 +272,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -1980,7 +1980,7 @@ index 3238cbcba567b1242c77e41f6b6f19a8d157fb4e..c5bfa7fffa1e7cbddf6d151f98ce92ef
      private final CustomBossEvents customBossEvents;
      private final ServerFunctionManager functionManager;
      private final FrameTimer frameTimer;
-@@ -453,60 +453,75 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -452,60 +452,75 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          LevelStorageSource.LevelStorageAccess worldSession = this.storageSource;
  
          Registry<LevelStem> dimensions = this.registries.compositeAccess().registryOrThrow(Registries.LEVEL_STEM);
@@ -2072,7 +2072,7 @@ index 3238cbcba567b1242c77e41f6b6f19a8d157fb4e..c5bfa7fffa1e7cbddf6d151f98ce92ef
                          MinecraftServer.LOGGER.warn("Could not create path for " + newWorld + "!");
                          MinecraftServer.LOGGER.info("---- Migration of old " + worldType + " folder failed ----");
                      }
-@@ -514,7 +529,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -513,7 +528,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
                  try {
                      worldSession = LevelStorageSource.createDefault(this.server.getWorldContainer().toPath()).validateAndCreateAccess(name, dimensionKey);
@@ -2081,7 +2081,7 @@ index 3238cbcba567b1242c77e41f6b6f19a8d157fb4e..c5bfa7fffa1e7cbddf6d151f98ce92ef
                      throw new RuntimeException(ex);
                  }
              }
-@@ -528,18 +543,18 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -527,18 +542,18 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              DynamicOps<Tag> dynamicops = RegistryOps.create(NbtOps.INSTANCE, (HolderLookup.Provider) worldloader_a.datapackWorldgen());
              Pair<WorldData, WorldDimensions.Complete> pair = worldSession.getDataTag(dynamicops, worldloader_a.dataConfiguration(), iregistry, worldloader_a.datapackWorldgen().allRegistriesLifecycle());
  
@@ -2104,7 +2104,7 @@ index 3238cbcba567b1242c77e41f6b6f19a8d157fb4e..c5bfa7fffa1e7cbddf6d151f98ce92ef
                      DedicatedServerProperties dedicatedserverproperties = ((DedicatedServer) this).getProperties();
  
                      worldsettings = new LevelSettings(dedicatedserverproperties.levelName, dedicatedserverproperties.gamemode, dedicatedserverproperties.hardcore, dedicatedserverproperties.difficulty, false, new GameRules(), worldloader_a.dataConfiguration());
-@@ -564,20 +579,20 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -563,20 +578,20 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              LevelStem worlddimension = (LevelStem) dimensions.get(dimensionKey);
  
              org.bukkit.generator.WorldInfo worldInfo = new org.bukkit.craftbukkit.generator.CraftWorldInfo(iworlddataserver, worldSession, org.bukkit.World.Environment.getEnvironment(dimension), worlddimension.type().value(), worlddimension.generator(), this.registryAccess()); // Paper
@@ -2129,7 +2129,7 @@ index 3238cbcba567b1242c77e41f6b6f19a8d157fb4e..c5bfa7fffa1e7cbddf6d151f98ce92ef
                  this.worldData = worlddata;
                  this.worldData.setGameType(((DedicatedServer) this).getProperties().gamemode); // From DedicatedServer.init
  
-@@ -588,13 +603,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -587,13 +602,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  this.readScoreboard(worldpersistentdata);
                  this.server.scoreboardManager = new org.bukkit.craftbukkit.scoreboard.CraftScoreboardManager(this, world.getScoreboard());
                  this.commandStorage = new CommandStorage(worldpersistentdata);
@@ -2146,7 +2146,7 @@ index 3238cbcba567b1242c77e41f6b6f19a8d157fb4e..c5bfa7fffa1e7cbddf6d151f98ce92ef
                      spawners = Collections.emptyList();
                  }
                  world = new ServerLevel(this, this.executor, worldSession, iworlddataserver, worldKey, worlddimension, worldloadlistener, flag, j, spawners, true, this.overworld().getRandomSequences(), org.bukkit.World.Environment.getEnvironment(dimension), gen, biomeProvider);
-@@ -608,12 +623,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -607,12 +622,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              // Paper - move up
              this.getPlayerList().addWorldborderListener(world);
  
@@ -2161,7 +2161,7 @@ index 3238cbcba567b1242c77e41f6b6f19a8d157fb4e..c5bfa7fffa1e7cbddf6d151f98ce92ef
              this.prepareLevels(worldserver.getChunkSource().chunkMap.progressListener, worldserver);
              //worldserver.entityManager.tick(); // SPIGOT-6526: Load pending entities so they are available to the API // Paper - rewrite chunk system, not required to "tick" anything
              this.server.getPluginManager().callEvent(new org.bukkit.event.world.WorldLoadEvent(worldserver.getWorld()));
-@@ -622,11 +637,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -621,11 +636,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          // Paper start - Handle collideRule team for player collision toggle
          final ServerScoreboard scoreboard = this.getScoreboard();
          final java.util.Collection<String> toRemove = scoreboard.getPlayerTeams().stream().filter(team -> team.getName().startsWith("collideRule_")).map(net.minecraft.world.scores.PlayerTeam::getName).collect(java.util.stream.Collectors.toList());
@@ -2175,7 +2175,7 @@ index 3238cbcba567b1242c77e41f6b6f19a8d157fb4e..c5bfa7fffa1e7cbddf6d151f98ce92ef
              this.getPlayerList().collideRuleTeamName = org.apache.commons.lang3.StringUtils.left("collideRule_" + java.util.concurrent.ThreadLocalRandom.current().nextInt(), 16);
              net.minecraft.world.scores.PlayerTeam collideTeam = scoreboard.addPlayerTeam(this.getPlayerList().collideRuleTeamName);
              collideTeam.setSeeFriendlyInvisibles(false); // Because we want to mimic them not being on a team at all
-@@ -1693,7 +1708,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1692,7 +1707,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      @DontObfuscate
      public String getServerModName() {
@@ -2185,7 +2185,7 @@ index 3238cbcba567b1242c77e41f6b6f19a8d157fb4e..c5bfa7fffa1e7cbddf6d151f98ce92ef
  
      public SystemReport fillSystemReport(SystemReport details) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 488a253e218409b5f0b4a872cee0928578fa7582..9d69c2f410078751497954ba16405b0c9aff0ff7 100644
+index acbcdc8cb1523044b1657e03a141fae6389a3686..c9fd0d3c66c2f9546e77123e655f8c930d68a000 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -168,7 +168,11 @@ public class ServerChunkCache extends ChunkSource {
@@ -2301,7 +2301,7 @@ index 9c6a2884c34a9f6e775103da42480cd6b8c693b3..3ef732bd50239c547eddfd0dcbc053a7
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 249d76acac9a91cd46f0b8a477511974a75d6f4a..bfe72630469c90bc2a62ea58a089420afbc74629 100644
+index ec4b73321205b472f19fa5bd4ad95893020d1340..41e0318f1b87f4159ae3d4b4732253487b68c2f4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -265,7 +265,7 @@ import javax.annotation.Nullable; // Paper

--- a/patches/server/0003-Build-Changes.patch
+++ b/patches/server/0003-Build-Changes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Build Changes
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index dd06e5f40b7c92ff31af51e83bfdc85ce160ee48..d7655979c24f7e24c8ee7dc0d242d92fd3fc69a9 100644
+index dd06e5f40b7c92ff31af51e83bfdc85ce160ee48..756e209e5bda8c8c93480aa396c424f9ee0f9eac 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -13,8 +13,13 @@ configurations.named(log4jPlugins.compileClasspathConfigurationName) {
@@ -17,7 +17,7 @@ index dd06e5f40b7c92ff31af51e83bfdc85ce160ee48..d7655979c24f7e24c8ee7dc0d242d92f
 +    // ASWM start
 +    implementation(project(":slimeworldmanager-api"))
 +    implementation(project(":core"))
-+    implementation("io.papermc.paper:paper-mojangapi:1.20-R0.1-SNAPSHOT") {
++    implementation("io.papermc.paper:paper-mojangapi:$version") {
 +        exclude("io.papermc.paper", "paper-api")
 +    }
 +    // ASWM end

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     implementation("org.spongepowered:configurate-yaml:4.1.2")
     implementation("org.bstats:bstats-bukkit:3.0.0")
     implementation("commons-io:commons-io:2.11.0")
-    compileOnly("io.papermc.paper:paper-api:1.20-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:$version")
 }
 
 tasks {
@@ -34,7 +34,7 @@ tasks {
     }
 
     runServer {
-        minecraftVersion("1.20.1")
+        minecraftVersion(project.property("mcVersion") as String)
     }
 }
 


### PR DESCRIPTION
## Changes
- Bumped bukkit API version to `1.20.1-R0.1-SNAPSHOT` for plugins compatibility
- Made it a bit easier to upgrade plugin to future minecraft versions. Now you just need to set `version` and `mcVersion` in `gradle.properties` :D (of course it may happen that you would need to update some libraries manually)

### About merge conflict
If there is a merge conflict, it will be probably in `paperRef` property. I can't actively fix merge conflicts, so if someone is going to merge this PR then you need to set `paperRef` to the latest.