### PR TITLE
Expose APIs for manual serialization/deserialization

### DIFF
--- a/api/src/main/java/com/infernalsuite/aswm/api/SlimePlugin.java
+++ b/api/src/main/java/com/infernalsuite/aswm/api/SlimePlugin.java
@@ -57,7 +57,7 @@ public interface SlimePlugin {
     SlimeWorld getWorld(String worldName);
 
     /**
-     * Gets an {@link ActiveSlimeWorld} from a given bukkit world, if backed by ASWM.
+     * Returns the loaded {@link ActiveSlimeWorld} from a given bukkit world, if backed by ASWM.
      *
      * @param bukkitWorld Bukkit World
      * @return active slime world instance, or {@code null} if the provided world is not backed by a slime world
@@ -104,7 +104,7 @@ public interface SlimePlugin {
      * @param world {@link SlimeWorld} world to be added to the server's world list
      * @return Returns a slime world representing a live minecraft world
      */
-    default SlimeWorld loadWorld(SlimeWorld world) throws UnknownWorldException, WorldLockedException, IOException {
+    default ActiveSlimeWorld loadWorld(SlimeWorld world) throws UnknownWorldException, WorldLockedException, IOException {
         return loadWorld(world, false);
     }
 
@@ -116,7 +116,7 @@ public interface SlimePlugin {
      * @param callWorldLoadEvent Whether or not to call {@link org.bukkit.event.world.WorldLoadEvent}
      * @return Returns a slime world representing a live minecraft world
      */
-    SlimeWorld loadWorld(SlimeWorld world, boolean callWorldLoadEvent) throws UnknownWorldException, WorldLockedException, IOException;
+    ActiveSlimeWorld loadWorld(SlimeWorld world, boolean callWorldLoadEvent) throws UnknownWorldException, WorldLockedException, IOException;
 
     /**
      * Migrates a {@link SlimeWorld} to another datasource.

--- a/api/src/main/java/com/infernalsuite/aswm/api/SlimePlugin.java
+++ b/api/src/main/java/com/infernalsuite/aswm/api/SlimePlugin.java
@@ -1,6 +1,8 @@
 package com.infernalsuite.aswm.api;
 
 import com.infernalsuite.aswm.api.exceptions.WorldLockedException;
+import com.infernalsuite.aswm.api.loaders.SlimeFormatAdapter;
+import com.infernalsuite.aswm.api.world.ActiveSlimeWorld;
 import com.infernalsuite.aswm.api.world.SlimeWorld;
 import com.infernalsuite.aswm.api.world.properties.SlimePropertyMap;
 import com.infernalsuite.aswm.api.exceptions.CorruptedWorldException;
@@ -11,6 +13,9 @@ import com.infernalsuite.aswm.api.exceptions.WorldAlreadyExistsException;
 import com.infernalsuite.aswm.api.exceptions.WorldLoadedException;
 import com.infernalsuite.aswm.api.exceptions.WorldTooBigException;
 import com.infernalsuite.aswm.api.loaders.SlimeLoader;
+import org.bukkit.World;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
@@ -52,6 +57,15 @@ public interface SlimePlugin {
     SlimeWorld getWorld(String worldName);
 
     /**
+     * Gets an {@link ActiveSlimeWorld} from a given bukkit world, if backed by ASWM.
+     *
+     * @param bukkitWorld Bukkit World
+     * @return active slime world instance, or {@code null} if the provided world is not backed by a slime world
+     */
+    @Nullable
+    ActiveSlimeWorld getActiveWorld(@NotNull World bukkitWorld);
+
+    /**
      * Gets a list of worlds which have been loaded by ASWM.
      * Note: The returned list is immutable, and encompasses a view of the loaded worlds at the time of the method call.
      *
@@ -73,6 +87,15 @@ public interface SlimePlugin {
      * @throws IOException                 if the world could not be stored.
      */
     SlimeWorld createEmptyWorld(SlimeLoader loader, String worldName, boolean readOnly, SlimePropertyMap propertyMap) throws WorldAlreadyExistsException, IOException;
+
+    /**
+     * Creates a read-only empty world without registering it or binding it to a loader.
+     *
+     * @param worldName Name the loaded world will assume.
+     * @param propertyMap A {@link SlimePropertyMap} with the world properties.
+     * @return A {@link SlimeWorld} that is empty, doesn't have a loader and is unregistered
+     */
+    SlimeWorld createUnboundEmptyWorld(@NotNull String worldName, @NotNull SlimePropertyMap propertyMap);
 
     /**
      * Generates a Minecraft World from a {@link SlimeWorld} and
@@ -162,4 +185,11 @@ public interface SlimePlugin {
 //    CompletableFuture<Void> asyncMigrateWorld(String worldName, SlimeLoader currentLoader, SlimeLoader newLoader);
 //
 //    CompletableFuture<Void> asyncImportWorld(File worldDir, String worldName, SlimeLoader loader);
+
+    /**
+     * Returns the default slime format adapter.
+     *
+     * @return A format adapter to serialize/deserialize worlds.
+     */
+    SlimeFormatAdapter getDefaultFormatAdapter();
 }

--- a/api/src/main/java/com/infernalsuite/aswm/api/loaders/SlimeFormatAdapter.java
+++ b/api/src/main/java/com/infernalsuite/aswm/api/loaders/SlimeFormatAdapter.java
@@ -1,0 +1,41 @@
+package com.infernalsuite.aswm.api.loaders;
+
+import com.infernalsuite.aswm.api.exceptions.CorruptedWorldException;
+import com.infernalsuite.aswm.api.exceptions.NewerFormatException;
+import com.infernalsuite.aswm.api.world.ActiveSlimeWorld;
+import com.infernalsuite.aswm.api.world.SlimeWorld;
+import com.infernalsuite.aswm.api.world.properties.SlimePropertyMap;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+
+public interface SlimeFormatAdapter {
+    /**
+     * Serializes a {@link SlimeWorld}.
+     * <p>
+     * <strong>Important: If the world is active, make sure to use the result of {@link ActiveSlimeWorld#getSnapshot()} as input.</strong>
+     *
+     * @param world World to serialize.
+     * @return Byte array.
+     */
+    byte[] serialize(@NotNull SlimeWorld world);
+
+    /**
+     * Deserializes a {@link SlimeWorld} from a byte array buffer.
+     * This will prepare the world so that it's ready to be registered (i.e. apply data fixers).
+     *
+     * @param worldName Name the loaded world will assume.
+     * @param serializedData Serialized data.
+     * @param loader The {@link SlimeLoader} that should be used to save the world once loaded. Can be null.
+     * @param propertyMap A {@link SlimePropertyMap} with the world properties.
+     * @param readOnly Whether the world should be marked as read-only (won't save automatically).
+     * @return In-memory slime world.
+     * @throws IOException             if something wrong happened while reading the serialized data.
+     * @throws CorruptedWorldException if the world retrieved cannot be parsed into a {@link SlimeWorld} object.
+     * @throws NewerFormatException    if the world uses a newer version of the SRF.
+     */
+    @NotNull SlimeWorld deserialize(@NotNull String worldName, byte[] serializedData, @Nullable SlimeLoader loader,
+                                    @NotNull SlimePropertyMap propertyMap, boolean readOnly)
+            throws IOException, CorruptedWorldException, NewerFormatException;
+}

--- a/api/src/main/java/com/infernalsuite/aswm/api/world/ActiveSlimeWorld.java
+++ b/api/src/main/java/com/infernalsuite/aswm/api/world/ActiveSlimeWorld.java
@@ -1,0 +1,13 @@
+package com.infernalsuite.aswm.api.world;
+
+/**
+ * A "running" slime world, from which immutable snapshots can be taken whenever wanted.
+ */
+public interface ActiveSlimeWorld {
+    /**
+     * Returns a snapshot of the world.
+     *
+     * @return Snapshot of the world, ready for serialization.
+     */
+    SlimeWorld getSnapshot();
+}

--- a/api/src/main/java/com/infernalsuite/aswm/api/world/ActiveSlimeWorld.java
+++ b/api/src/main/java/com/infernalsuite/aswm/api/world/ActiveSlimeWorld.java
@@ -1,13 +1,25 @@
 package com.infernalsuite.aswm.api.world;
 
+import org.bukkit.World;
+import org.jetbrains.annotations.NotNull;
+
 /**
- * A "running" slime world, from which immutable snapshots can be taken whenever wanted.
+ * A "running" slime world, bound to a loaded ("live") Minecraft world.
  */
-public interface ActiveSlimeWorld {
+public interface ActiveSlimeWorld extends SlimeWorld {
+    /**
+     * Returns the bukkit world for this loaded slime world.
+     *
+     * @return Bukkit world
+     */
+    @NotNull
+    World getBukkitWorld();
+
     /**
      * Returns a snapshot of the world.
      *
      * @return Snapshot of the world, ready for serialization.
      */
+    @NotNull
     SlimeWorld getSnapshot();
 }

--- a/api/src/main/java/com/infernalsuite/aswm/api/world/SlimeWorldInstance.java
+++ b/api/src/main/java/com/infernalsuite/aswm/api/world/SlimeWorldInstance.java
@@ -11,7 +11,7 @@ public interface SlimeWorldInstance extends ActiveSlimeWorld {
 
     World getBukkitWorld();
 
-    SlimeWorld getSlimeWorldMirror();
+    ActiveSlimeWorld getSlimeWorldMirror();
 
     SlimePropertyMap getPropertyMap();
 

--- a/api/src/main/java/com/infernalsuite/aswm/api/world/SlimeWorldInstance.java
+++ b/api/src/main/java/com/infernalsuite/aswm/api/world/SlimeWorldInstance.java
@@ -5,7 +5,7 @@ import com.infernalsuite.aswm.api.world.properties.SlimePropertyMap;
 import com.infernalsuite.aswm.api.loaders.SlimeLoader;
 import org.bukkit.World;
 
-public interface SlimeWorldInstance {
+public interface SlimeWorldInstance extends ActiveSlimeWorld {
 
     String getName();
 

--- a/core/src/main/java/com/infernalsuite/aswm/serialization/slime/DefaultSlimeFormatAdapter.java
+++ b/core/src/main/java/com/infernalsuite/aswm/serialization/slime/DefaultSlimeFormatAdapter.java
@@ -1,0 +1,39 @@
+package com.infernalsuite.aswm.serialization.slime;
+
+import com.infernalsuite.aswm.api.SlimeNMSBridge;
+import com.infernalsuite.aswm.api.exceptions.CorruptedWorldException;
+import com.infernalsuite.aswm.api.exceptions.NewerFormatException;
+import com.infernalsuite.aswm.api.loaders.SlimeFormatAdapter;
+import com.infernalsuite.aswm.api.loaders.SlimeLoader;
+import com.infernalsuite.aswm.api.world.SlimeWorld;
+import com.infernalsuite.aswm.api.world.properties.SlimePropertyMap;
+import com.infernalsuite.aswm.serialization.slime.reader.SlimeWorldReaderRegistry;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+
+public class DefaultSlimeFormatAdapter implements SlimeFormatAdapter {
+    private final @Nullable Consumer<String> infoLog;
+
+    public DefaultSlimeFormatAdapter(@Nullable Consumer<String> infoLog) {
+        this.infoLog = infoLog;
+    }
+
+    @Override
+    public byte[] serialize(@NotNull SlimeWorld world) {
+        return SlimeSerializer.serialize(world);
+    }
+
+    @Override
+    public @NotNull SlimeWorld deserialize(@NotNull String worldName, byte[] serializedData, @Nullable SlimeLoader loader,
+                                           @NotNull SlimePropertyMap propertyMap, boolean readOnly)
+            throws CorruptedWorldException, NewerFormatException, IOException {
+        SlimeWorld slimeWorld = SlimeWorldReaderRegistry.readWorld(loader, worldName, serializedData, propertyMap, readOnly);
+        if (infoLog != null) {
+            infoLog.accept("Applying data fixers for " + worldName + ".");
+        }
+        return SlimeNMSBridge.instance().applyDataFixers(slimeWorld);
+    }
+}

--- a/plugin/src/main/java/com/grinderwolf/swm/plugin/SWMPlugin.java
+++ b/plugin/src/main/java/com/grinderwolf/swm/plugin/SWMPlugin.java
@@ -328,14 +328,14 @@ public class SWMPlugin extends JavaPlugin implements SlimePlugin, Listener {
     }
 
     @Override
-    public SlimeWorld loadWorld(SlimeWorld slimeWorld, boolean callWorldLoadEvent) throws WorldLockedException, UnknownWorldException, IOException {
+    public ActiveSlimeWorld loadWorld(SlimeWorld slimeWorld, boolean callWorldLoadEvent) throws WorldLockedException, UnknownWorldException, IOException {
         Objects.requireNonNull(slimeWorld, "SlimeWorld cannot be null");
 
         if (!slimeWorld.isReadOnly() && slimeWorld.getLoader() != null) {
             slimeWorld.getLoader().acquireLock(slimeWorld.getName());
         }
         SlimeWorldInstance instance = BRIDGE_INSTANCE.loadInstance(slimeWorld);
-        SlimeWorld mirror = instance.getSlimeWorldMirror();
+        ActiveSlimeWorld mirror = instance.getSlimeWorldMirror();
 
         Bukkit.getPluginManager().callEvent(new LoadSlimeWorldEvent(mirror));
         if (callWorldLoadEvent) {


### PR DESCRIPTION
* Adds a new interface `ActiveSlimeWorld` that represents a live world, from which a snapshot can be taken at any time
* Make `loadWorld` return an `ActiveSlimeWorld` to easily get the bound bukkit world
* Adds a `SlimeFormatAdapter` interface for manual (de)serialization of slime worlds. The plugin provides a default implementation that calls the existing, unchanged, internal slime serializer.