### PR TITLE
Make SlimeWorld a PersistentDataHolder

### DIFF
--- a/api/src/main/java/com/infernalsuite/aswm/api/SlimeNMSBridge.java
+++ b/api/src/main/java/com/infernalsuite/aswm/api/SlimeNMSBridge.java
@@ -1,9 +1,11 @@
 package com.infernalsuite.aswm.api;
 
+import com.flowpowered.nbt.CompoundMap;
 import com.infernalsuite.aswm.api.world.SlimeWorld;
 import com.infernalsuite.aswm.api.world.SlimeWorldInstance;
 import net.kyori.adventure.util.Services;
 import org.bukkit.World;
+import org.bukkit.persistence.PersistentDataContainer;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.io.IOException;
@@ -34,6 +36,9 @@ public interface SlimeNMSBridge {
         return Holder.INSTANCE;
     }
 
+    void extractCraftPDC(PersistentDataContainer source, CompoundMap target);
+
+    PersistentDataContainer extractCompoundMapIntoCraftPDC(CompoundMap source);
 
     @ApiStatus.Internal
     static class Holder {

--- a/api/src/main/java/com/infernalsuite/aswm/api/world/SlimeWorld.java
+++ b/api/src/main/java/com/infernalsuite/aswm/api/world/SlimeWorld.java
@@ -5,6 +5,7 @@ import com.infernalsuite.aswm.api.SlimePlugin;
 import com.flowpowered.nbt.CompoundTag;
 import com.infernalsuite.aswm.api.exceptions.WorldAlreadyExistsException;
 import com.infernalsuite.aswm.api.loaders.SlimeLoader;
+import org.bukkit.persistence.PersistentDataHolder;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -13,7 +14,7 @@ import java.util.Map;
 /**
  * In-memory representation of a SRF world.
  */
-public interface SlimeWorld {
+public interface SlimeWorld extends PersistentDataHolder {
 
     /**
      * Returns the name of the world.

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -3,5 +3,6 @@ plugins {
 
 dependencies {
     compileOnly(project(":api"))
+    compileOnly(project(":slimeworldmanager-api"))
     implementation("com.github.luben:zstd-jni:1.5.2-2")
 }

--- a/core/src/main/java/com/infernalsuite/aswm/pdc/FlowPersistentDataContainer.java
+++ b/core/src/main/java/com/infernalsuite/aswm/pdc/FlowPersistentDataContainer.java
@@ -1,0 +1,154 @@
+package com.infernalsuite.aswm.pdc;
+
+import com.flowpowered.nbt.CompoundMap;
+import com.flowpowered.nbt.CompoundTag;
+import com.flowpowered.nbt.Tag;
+import com.flowpowered.nbt.stream.NBTInputStream;
+import com.flowpowered.nbt.stream.NBTOutputStream;
+import org.bukkit.NamespacedKey;
+import org.bukkit.persistence.PersistentDataAdapterContext;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteOrder;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+public class FlowPersistentDataContainer implements PersistentDataContainer, PersistentDataAdapterContext {
+
+    private final CompoundTag root;
+    private final FlowTypeRegistry registry;
+
+    public FlowPersistentDataContainer(CompoundTag root, FlowTypeRegistry typeRegistry) {
+        this.root = root;
+        this.registry = typeRegistry;
+    }
+
+    public FlowPersistentDataContainer(CompoundTag root) {
+        this.root = root;
+        this.registry = FlowTypeRegistry.DEFAULT;
+    }
+
+    @Override
+    public <T, Z> void set(@NotNull NamespacedKey key, @NotNull PersistentDataType<T, Z> type, @NotNull Z value) {
+        var name = key.toString();
+        root.getValue().put(name, registry.wrap(name, type.getPrimitiveType(), type.toPrimitive(value, getAdapterContext())));
+    }
+
+    @Override
+    public <T, Z> boolean has(@NotNull NamespacedKey key, @NotNull PersistentDataType<T, Z> type) {
+        var value = root.getValue().get(key.toString());
+
+        if (value == null) {
+            return false;
+        }
+
+        return registry.isInstanceOf(type.getPrimitiveType(), value);
+    }
+
+    @Override
+    public <T, Z> @Nullable Z get(@NotNull NamespacedKey key, @NotNull PersistentDataType<T, Z> type) {
+        var value = root.getValue().get(key.toString());
+
+        if (value == null) {
+            return null;
+        }
+
+        return type.fromPrimitive(registry.extract(type.getPrimitiveType(), (Tag<T>) value), getAdapterContext());
+    }
+
+    @Override
+    public <T, Z> @NotNull Z getOrDefault(@NotNull NamespacedKey key, @NotNull PersistentDataType<T, Z> type, @NotNull Z defaultValue) {
+        var value = get(key, type);
+        return value == null ? defaultValue : value;
+    }
+
+    @Override
+    public @NotNull Set<NamespacedKey> getKeys() {
+        var keys = new HashSet<NamespacedKey>();
+
+        for (String key : root.getValue().keySet()) {
+            String[] keyData = key.split(":", 2);
+            if (keyData.length == 2) {
+                keys.add(new NamespacedKey(keyData[0], keyData[1]));
+            }
+        }
+
+        return keys;
+    }
+
+    @Override
+    public void remove(@NotNull NamespacedKey key) {
+        root.getValue().remove(key.toString());
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return root.getValue().isEmpty();
+    }
+
+    @Override
+    public @NotNull PersistentDataAdapterContext getAdapterContext() {
+        return this;
+    }
+
+    @Override
+    public boolean has(@NotNull NamespacedKey key) {
+        return root.getValue().containsKey(key.toString());
+    }
+
+    @Override
+    public byte @NotNull [] serializeToBytes() throws IOException {
+        if (root == null || root.getValue().isEmpty()) {
+            return new byte[0];
+        }
+        ByteArrayOutputStream outByteStream = new ByteArrayOutputStream();
+        NBTOutputStream outStream = new NBTOutputStream(outByteStream, NBTInputStream.NO_COMPRESSION, ByteOrder.BIG_ENDIAN);
+        outStream.writeTag(root);
+
+        return outByteStream.toByteArray();
+    }
+
+    @Override
+    public void readFromBytes(byte @NotNull [] bytes, boolean clear) throws IOException {
+        if (bytes.length == 0) {
+            return;
+        }
+
+        NBTInputStream stream = new NBTInputStream(new ByteArrayInputStream(bytes), NBTInputStream.NO_COMPRESSION, ByteOrder.BIG_ENDIAN);
+        var compound = (com.flowpowered.nbt.CompoundTag) stream.readTag();
+
+        if (clear) {
+            root.getValue().clear();
+        }
+
+        root.getValue().putAll(compound.getValue());
+    }
+
+    @Override
+    public @NotNull PersistentDataContainer newPersistentDataContainer() {
+        return new FlowPersistentDataContainer(new CompoundTag("root", new CompoundMap()), registry);
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = 3;
+        hashCode += root.hashCode(); // We will simply add the tag hashcode
+        return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof FlowPersistentDataContainer flow)) {
+            return false;
+        }
+
+        return Objects.equals(root, flow.root);
+    }
+}

--- a/core/src/main/java/com/infernalsuite/aswm/pdc/FlowPersistentDataContainer.java
+++ b/core/src/main/java/com/infernalsuite/aswm/pdc/FlowPersistentDataContainer.java
@@ -23,16 +23,20 @@ import java.util.Set;
 public class FlowPersistentDataContainer implements PersistentDataContainer, PersistentDataAdapterContext {
 
     private final CompoundTag root;
-    private final FlowTypeRegistry registry;
+    private final FlowDataTypeRegistry registry;
 
-    public FlowPersistentDataContainer(CompoundTag root, FlowTypeRegistry typeRegistry) {
+    public FlowPersistentDataContainer(CompoundTag root, FlowDataTypeRegistry typeRegistry) {
         this.root = root;
         this.registry = typeRegistry;
     }
 
     public FlowPersistentDataContainer(CompoundTag root) {
         this.root = root;
-        this.registry = FlowTypeRegistry.DEFAULT;
+        this.registry = FlowDataTypeRegistry.DEFAULT;
+    }
+
+    protected CompoundTag getRoot() {
+        return root;
     }
 
     @Override

--- a/core/src/main/java/com/infernalsuite/aswm/pdc/FlowTypeRegistry.java
+++ b/core/src/main/java/com/infernalsuite/aswm/pdc/FlowTypeRegistry.java
@@ -1,0 +1,184 @@
+package com.infernalsuite.aswm.pdc;
+
+import com.flowpowered.nbt.*;
+import com.google.common.base.Preconditions;
+import com.google.common.primitives.Primitives;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+public class FlowTypeRegistry {
+
+    public static final FlowTypeRegistry DEFAULT = new FlowTypeRegistry();
+    private final Map<Class<?>, TagAdapter<?, ?>> adapters = new ConcurrentHashMap<>();
+
+    private <T, Z extends Tag<T>> TagAdapter<T, Z> createAdapter(Class<T> primitiveType, Class<Z> nbtBaseType, BiFunction<String, T, Z> builder, Function<Z, T> extractor) {
+        return new TagAdapter<>(primitiveType, nbtBaseType, builder, extractor);
+    }
+
+    private <T, Z extends Tag<T>> TagAdapter<T, Z> obtainAdapter(Class<T> type) {
+        // Should be safe
+        //noinspection unchecked
+        return (TagAdapter<T, Z>) adapters.computeIfAbsent(type, this::createAdapter);
+    }
+
+    /**
+     * Creates a TagAdapter object based on the given type.
+     * <br>
+     * <b>Unlike CraftBukkit, this implementation does not allow complex tags</b>, as it would require to cast them to CraftPersistentDataContainer which is not available from this context.
+     *
+     * @param type The class representing the type to be converted.
+     * @return A TagAdapter object that can convert the given type to the corresponding Tag implementation.
+     * @throws IllegalArgumentException if a valid TagAdapter implementation cannot be found for the requested type.
+     */
+    private <T> TagAdapter<?, ?> createAdapter(Class<T> type) throws IllegalArgumentException {
+        if (!Primitives.isWrapperType(type)) {
+            type = Primitives.wrap(type); //Make sure we will always "switch" over the wrapper types
+        }
+        // This would really make use of pattern matching in JDK 21 :(
+
+        // Convert Byte to ByteTag
+        if (Objects.equals(Byte.class, type)) {
+            return createAdapter(Byte.class, ByteTag.class, ByteTag::new, ByteTag::getValue);
+        }
+        // Convert Short to ShortTag
+        if (Objects.equals(Short.class, type)) {
+            return createAdapter(Short.class, ShortTag.class, ShortTag::new, ShortTag::getValue);
+        }
+        // Convert Integer to IntTag
+        if (Objects.equals(Integer.class, type)) {
+            return createAdapter(Integer.class, IntTag.class, IntTag::new, IntTag::getValue);
+        }
+        // Convert Long to LongTag
+        if (Objects.equals(Long.class, type)) {
+            return createAdapter(Long.class, LongTag.class, LongTag::new, LongTag::getValue);
+        }
+        // Convert Float to FloatTag
+        if (Objects.equals(Float.class, type)) {
+            return createAdapter(Float.class, FloatTag.class, FloatTag::new, FloatTag::getValue);
+        }
+        // Convert Double to DoubleTag
+        if (Objects.equals(Double.class, type)) {
+            return createAdapter(Double.class, DoubleTag.class, DoubleTag::new, DoubleTag::getValue);
+        }
+
+        // Convert String to StringTag
+        if (Objects.equals(String.class, type)) {
+            return createAdapter(String.class, StringTag.class, StringTag::new, StringTag::getValue);
+        }
+
+        // Convert byte[] to ByteArrayTag
+        if (Objects.equals(byte[].class, type)) {
+            return createAdapter(byte[].class, ByteArrayTag.class, ByteArrayTag::new, ByteArrayTag::getValue);
+        }
+        // Convert int[] to IntArrayTag
+        if (Objects.equals(int[].class, type)) {
+            return createAdapter(int[].class, IntArrayTag.class, IntArrayTag::new, IntArrayTag::getValue);
+        }
+        // Convert long[] to LongArrayTag
+        if (Objects.equals(long[].class, type)) {
+            return createAdapter(long[].class, LongArrayTag.class, LongArrayTag::new, LongArrayTag::getValue);
+        }
+        // Convert short[] to ShortArrayTag
+        if (Objects.equals(short[].class, type)) {
+            return createAdapter(short[].class, ShortArrayTag.class, ShortArrayTag::new, ShortArrayTag::getValue);
+        }
+
+        throw new IllegalArgumentException("Could not find a valid TagAdapter implementation for the requested type " + type.getSimpleName());
+    }
+
+    /**
+     * Wraps the passed value into a tag instance.
+     *
+     * @param type  the type of the passed value
+     * @param value the value to be stored in the tag
+     * @param key   the key to store the value under
+     * @param <T>   the generic type of the value
+     * @return the created tag instance
+     * @throws IllegalArgumentException if no suitable tag type adapter for this type was found
+     */
+    public <T> Tag<T> wrap(String key, Class<T> type, T value) throws IllegalArgumentException {
+        return obtainAdapter(type)
+                .build(key, value);
+    }
+
+    /**
+     * Returns if the tag instance matches the provided primitive type.
+     *
+     * @param type the type of the primitive value
+     * @param base the base instance to check
+     * @param <T>  the generic type of the type
+     * @return if the base stores values of the primitive type passed
+     * @throws IllegalArgumentException if no suitable tag type adapter for this
+     *                                  type was found
+     */
+    public <T> boolean isInstanceOf(Class<T> type, Tag<?> base) {
+        return obtainAdapter(type)
+                .isInstance(base);
+    }
+
+    /**
+     * Extracts the value out of the provided tag.
+     *
+     * @param type the type of the value to extract
+     * @param tag  the tag to extract the value from
+     * @param <T>  the generic type of the value stored inside the tag
+     * @return the extracted value
+     * @throws IllegalArgumentException if the passed base is not an instanced of the defined base type and therefore is not applicable to the extractor function
+     * @throws IllegalArgumentException if the found object is not of type passed
+     * @throws IllegalArgumentException if no suitable tag type adapter for this type was found
+     */
+    public <T> T extract(Class<T> type, Tag<T> tag) throws ClassCastException, IllegalArgumentException {
+        var adapter = obtainAdapter(type);
+        Preconditions.checkArgument(adapter.isInstance(tag), "The found tag instance (%s) cannot store %s", tag.getClass().getSimpleName(), type.getSimpleName());
+
+        Object foundValue = adapter.extract(tag);
+        Preconditions.checkArgument(type.isInstance(foundValue), "The found object is of the type %s. Expected type %s", foundValue.getClass().getSimpleName(), type.getSimpleName());
+        return type.cast(foundValue);
+    }
+
+    private record TagAdapter<T, Z extends Tag<T>>(Class<T> primitiveType, Class<Z> nbtBaseType,
+                                                   BiFunction<String, T, Z> builder, Function<Z, T> extractor) {
+        /**
+         * This method will extract the value stored in the tag, according to
+         * the expected primitive type.
+         *
+         * @param base the base to extract from
+         * @return the value stored inside of the tag
+         * @throws ClassCastException if the passed base is not an instanced of
+         *                            the defined base type and therefore is not applicable to the
+         *                            extractor function
+         */
+        T extract(Tag<T> base) {
+            Preconditions.checkArgument(this.nbtBaseType.isInstance(base), "The provided NBTBase was of the type %s. Expected type %s", base.getClass().getSimpleName(), this.nbtBaseType.getSimpleName());
+            return this.extractor.apply(this.nbtBaseType.cast(base));
+        }
+
+        /**
+         * Builds a tag instance wrapping around the provided value object.
+         *
+         * @param value the value to store inside the created tag
+         * @return the new tag instance
+         * @throws ClassCastException if the passed value object is not of the
+         *                            defined primitive type and therefore is not applicable to the builder
+         *                            function
+         */
+        Z build(String key, Object value) {
+            Preconditions.checkArgument(this.primitiveType.isInstance(value), "The provided value was of the type %s. Expected type %s", value.getClass().getSimpleName(), this.primitiveType.getSimpleName());
+            return this.builder.apply(key, this.primitiveType.cast(value));
+        }
+
+        /**
+         * Returns if the tag instance matches the adapters one.
+         *
+         * @param base the base to check
+         * @return if the tag was an instance of the set type
+         */
+        boolean isInstance(Tag<?> base) {
+            return this.nbtBaseType.isInstance(base);
+        }
+    }
+}

--- a/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonSlimeWorld.java
+++ b/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonSlimeWorld.java
@@ -8,7 +8,6 @@ import com.infernalsuite.aswm.api.world.SlimeChunk;
 import com.infernalsuite.aswm.api.world.SlimeWorld;
 import com.infernalsuite.aswm.api.world.properties.SlimePropertyMap;
 import com.infernalsuite.aswm.pdc.FlowPersistentDataContainer;
-import com.infernalsuite.aswm.pdc.FlowTypeRegistry;
 import com.infernalsuite.aswm.serialization.slime.SlimeSerializer;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.jetbrains.annotations.NotNull;

--- a/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonSlimeWorld.java
+++ b/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonSlimeWorld.java
@@ -7,23 +7,47 @@ import com.infernalsuite.aswm.api.loaders.SlimeLoader;
 import com.infernalsuite.aswm.api.world.SlimeChunk;
 import com.infernalsuite.aswm.api.world.SlimeWorld;
 import com.infernalsuite.aswm.api.world.properties.SlimePropertyMap;
+import com.infernalsuite.aswm.pdc.FlowPersistentDataContainer;
+import com.infernalsuite.aswm.pdc.FlowTypeRegistry;
 import com.infernalsuite.aswm.serialization.slime.SlimeSerializer;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
-public record SkeletonSlimeWorld(
-        String name,
-        @Nullable SlimeLoader loader,
-        boolean readOnly,
-        Map<ChunkPos, SlimeChunk> chunkStorage,
-        CompoundTag extraSerialized,
-        SlimePropertyMap slimePropertyMap,
-        int dataVersion
-) implements SlimeWorld {
+public final class SkeletonSlimeWorld implements SlimeWorld {
+    private final String name;
+    private final @Nullable SlimeLoader loader;
+    private final boolean readOnly;
+    private final Map<ChunkPos, SlimeChunk> chunkStorage;
+    private final CompoundTag extraSerialized;
+    private final SlimePropertyMap slimePropertyMap;
+    private final int dataVersion;
+    private final FlowPersistentDataContainer pdc;
+
+    public SkeletonSlimeWorld(
+            String name,
+            @Nullable SlimeLoader loader,
+            boolean readOnly,
+            Map<ChunkPos, SlimeChunk> chunkStorage,
+            CompoundTag extraSerialized,
+            SlimePropertyMap slimePropertyMap,
+            int dataVersion
+    ) {
+        this.name = name;
+        this.loader = loader;
+        this.readOnly = readOnly;
+        this.chunkStorage = chunkStorage;
+        this.extraSerialized = extraSerialized;
+        this.slimePropertyMap = slimePropertyMap;
+        this.dataVersion = dataVersion;
+        this.pdc = new FlowPersistentDataContainer(extraSerialized);
+    }
 
     @Override
     public String getName() {
@@ -100,6 +124,70 @@ public record SkeletonSlimeWorld(
         }
 
         return cloned;
+    }
+
+    @Override
+    public @NotNull PersistentDataContainer getPersistentDataContainer() {
+        return this.pdc;
+    };
+
+    public String name() {
+        return name;
+    }
+
+    public @Nullable SlimeLoader loader() {
+        return loader;
+    }
+
+    public boolean readOnly() {
+        return readOnly;
+    }
+
+    public Map<ChunkPos, SlimeChunk> chunkStorage() {
+        return chunkStorage;
+    }
+
+    public CompoundTag extraSerialized() {
+        return extraSerialized;
+    }
+
+    public SlimePropertyMap slimePropertyMap() {
+        return slimePropertyMap;
+    }
+
+    public int dataVersion() {
+        return dataVersion;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (SkeletonSlimeWorld) obj;
+        return Objects.equals(this.name, that.name) &&
+               Objects.equals(this.loader, that.loader) &&
+               this.readOnly == that.readOnly &&
+               Objects.equals(this.chunkStorage, that.chunkStorage) &&
+               Objects.equals(this.extraSerialized, that.extraSerialized) &&
+               Objects.equals(this.slimePropertyMap, that.slimePropertyMap) &&
+               this.dataVersion == that.dataVersion;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, loader, readOnly, chunkStorage, extraSerialized, slimePropertyMap, dataVersion);
+    }
+
+    @Override
+    public String toString() {
+        return "SkeletonSlimeWorld[" +
+               "name=" + name + ", " +
+               "loader=" + loader + ", " +
+               "readOnly=" + readOnly + ", " +
+               "chunkStorage=" + chunkStorage + ", " +
+               "extraSerialized=" + extraSerialized + ", " +
+               "slimePropertyMap=" + slimePropertyMap + ", " +
+               "dataVersion=" + dataVersion + ']';
     }
 
 }

--- a/patches/server/0011-Make-SlimeWorld-a-PersistentDataHolder.patch
+++ b/patches/server/0011-Make-SlimeWorld-a-PersistentDataHolder.patch
@@ -4,6 +4,71 @@ Date: Thu, 26 Oct 2023 14:55:39 +0200
 Subject: [PATCH] Make SlimeWorld a PersistentDataHolder
 
 
+diff --git a/src/main/java/com/infernalsuite/aswm/SlimeNMSBridgeImpl.java b/src/main/java/com/infernalsuite/aswm/SlimeNMSBridgeImpl.java
+index 97a3c0401d1bcf34d8022da5163b8169a66fd5b3..21c3ea3596a1f954618348afae2b2f7f058393d1 100644
+--- a/src/main/java/com/infernalsuite/aswm/SlimeNMSBridgeImpl.java
++++ b/src/main/java/com/infernalsuite/aswm/SlimeNMSBridgeImpl.java
+@@ -1,5 +1,6 @@
+ package com.infernalsuite.aswm;
+ 
++import com.flowpowered.nbt.CompoundMap;
+ import com.infernalsuite.aswm.api.SlimeNMSBridge;
+ import com.infernalsuite.aswm.api.world.SlimeWorld;
+ import com.infernalsuite.aswm.api.world.SlimeWorldInstance;
+@@ -12,6 +13,7 @@ import net.kyori.adventure.util.Services;
+ import net.minecraft.SharedConstants;
+ import net.minecraft.core.registries.Registries;
+ import net.minecraft.nbt.CompoundTag;
++import net.minecraft.nbt.Tag;
+ import net.minecraft.resources.ResourceKey;
+ import net.minecraft.resources.ResourceLocation;
+ import net.minecraft.server.MinecraftServer;
+@@ -30,13 +32,18 @@ import org.apache.logging.log4j.Logger;
+ import org.bukkit.Bukkit;
+ import org.bukkit.World;
+ import org.bukkit.craftbukkit.CraftWorld;
++import org.bukkit.craftbukkit.persistence.CraftPersistentDataContainer;
++import org.bukkit.craftbukkit.persistence.CraftPersistentDataTypeRegistry;
++import org.bukkit.persistence.PersistentDataContainer;
+ import org.jetbrains.annotations.Nullable;
+ 
+ import java.io.IOException;
+ import java.util.Locale;
++import java.util.Map;
+ 
+ public class SlimeNMSBridgeImpl implements SlimeNMSBridge {
+ 
++    private static final CraftPersistentDataTypeRegistry REGISTRY = new CraftPersistentDataTypeRegistry();
+     private static final SimpleDataFixerConverter DATA_FIXER_CONVERTER = new SimpleDataFixerConverter();
+ 
+     private static final Logger LOGGER = LogManager.getLogger("SWM");
+@@ -49,6 +56,26 @@ public class SlimeNMSBridgeImpl implements SlimeNMSBridge {
+         return (SlimeNMSBridgeImpl) SlimeNMSBridge.instance();
+     }
+ 
++    @Override
++    public void extractCraftPDC(PersistentDataContainer source, CompoundMap target) {
++        if (source instanceof CraftPersistentDataContainer craftPDC) {
++            for (Map.Entry<String, Tag> entry : craftPDC.getRaw().entrySet()) {
++                target.put(Converter.convertTag(entry.getKey(), entry.getValue()));
++            }
++        } else {
++            throw new IllegalArgumentException("PersistentDataContainer is not a CraftPersistentDataContainer");
++        }
++    }
++
++    @Override
++    public PersistentDataContainer extractCompoundMapIntoCraftPDC(CompoundMap source) {
++        var container = new CraftPersistentDataContainer(REGISTRY);
++        for (Map.Entry<String, com.flowpowered.nbt.Tag<?>> entry : source.entrySet()) {
++            container.put(entry.getKey(), Converter.convertTag(entry.getValue()));
++        }
++        return container;
++    }
++
+     @Override
+     public boolean loadOverworldOverride() {
+         if (defaultWorld == null) {
 diff --git a/src/main/java/com/infernalsuite/aswm/level/NMSSlimeWorld.java b/src/main/java/com/infernalsuite/aswm/level/NMSSlimeWorld.java
 index 9a27369c00345bbb94aa19f77687269dc94c0b0a..07e542e3f75bf272f53345dc040d90358e7d7b2d 100644
 --- a/src/main/java/com/infernalsuite/aswm/level/NMSSlimeWorld.java

--- a/patches/server/0011-Make-SlimeWorld-a-PersistentDataHolder.patch
+++ b/patches/server/0011-Make-SlimeWorld-a-PersistentDataHolder.patch
@@ -1,0 +1,77 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: kyngs <kyngs@users.noreply.github.com>
+Date: Thu, 26 Oct 2023 14:55:39 +0200
+Subject: [PATCH] Make SlimeWorld a PersistentDataHolder
+
+
+diff --git a/src/main/java/com/infernalsuite/aswm/level/NMSSlimeWorld.java b/src/main/java/com/infernalsuite/aswm/level/NMSSlimeWorld.java
+index 9a27369c00345bbb94aa19f77687269dc94c0b0a..07e542e3f75bf272f53345dc040d90358e7d7b2d 100644
+--- a/src/main/java/com/infernalsuite/aswm/level/NMSSlimeWorld.java
++++ b/src/main/java/com/infernalsuite/aswm/level/NMSSlimeWorld.java
+@@ -9,6 +9,8 @@ import com.infernalsuite.aswm.api.world.properties.SlimePropertyMap;
+ import net.minecraft.SharedConstants;
+ import net.minecraft.server.level.ChunkHolder;
+ import net.minecraft.world.level.chunk.LevelChunk;
++import org.bukkit.persistence.PersistentDataContainer;
++import org.jetbrains.annotations.NotNull;
+ 
+ import java.io.IOException;
+ import java.util.Collection;
+@@ -88,4 +90,9 @@ public class NMSSlimeWorld implements SlimeWorld {
+     public int getDataVersion() {
+         return SharedConstants.getCurrentVersion().getDataVersion().getVersion();
+     }
++
++    @Override
++    public @NotNull PersistentDataContainer getPersistentDataContainer() {
++        return memoryWorld.getPersistentDataContainer();
++    }
+ }
+\ No newline at end of file
+diff --git a/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java b/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java
+index 03f0a5c88a6b2d28a5a69649fc1295b51aaf879f..fe67f7d920f0599e642493adfdec5fce6c70259f 100644
+--- a/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java
++++ b/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java
+@@ -5,6 +5,7 @@ import com.infernalsuite.aswm.ChunkPos;
+ import com.infernalsuite.aswm.Converter;
+ import com.infernalsuite.aswm.api.exceptions.WorldAlreadyExistsException;
+ import com.infernalsuite.aswm.api.loaders.SlimeLoader;
++import com.infernalsuite.aswm.pdc.FlowPersistentDataContainer;
+ import com.infernalsuite.aswm.serialization.slime.SlimeSerializer;
+ import com.infernalsuite.aswm.skeleton.SkeletonCloning;
+ import com.infernalsuite.aswm.skeleton.SkeletonSlimeWorld;
+@@ -19,6 +20,8 @@ import net.minecraft.world.level.chunk.UpgradeData;
+ import net.minecraft.world.level.material.Fluid;
+ import net.minecraft.world.ticks.LevelChunkTicks;
+ import org.bukkit.World;
++import org.bukkit.persistence.PersistentDataContainer;
++import org.jetbrains.annotations.NotNull;
+ 
+ import java.io.IOException;
+ import java.util.ArrayList;
+@@ -38,6 +41,7 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
+     private final SlimeWorld liveWorld;
+ 
+     private final CompoundTag extra;
++    private final FlowPersistentDataContainer extraPDC;
+     private final SlimePropertyMap propertyMap;
+     private final SlimeLoader loader;
+ 
+@@ -60,6 +64,7 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
+             this.chunkStorage.put(pos, initial);
+         }
+ 
++        this.extraPDC = new FlowPersistentDataContainer(extra);
+         this.liveWorld = new NMSSlimeWorld(this);
+     }
+ 
+@@ -260,4 +265,9 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
+     public SlimeLevelInstance getInstance() {
+         return instance;
+     }
++
++    @Override
++    public @NotNull PersistentDataContainer getPersistentDataContainer() {
++        return null;
++    }
+ }

--- a/patches/server/0011-Make-SlimeWorld-a-PersistentDataHolder.patch
+++ b/patches/server/0011-Make-SlimeWorld-a-PersistentDataHolder.patch
@@ -94,7 +94,7 @@ index 9a27369c00345bbb94aa19f77687269dc94c0b0a..07e542e3f75bf272f53345dc040d9035
  }
 \ No newline at end of file
 diff --git a/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java b/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java
-index 03f0a5c88a6b2d28a5a69649fc1295b51aaf879f..fe67f7d920f0599e642493adfdec5fce6c70259f 100644
+index 03f0a5c88a6b2d28a5a69649fc1295b51aaf879f..092dae1f9e68f1c395cd0f8151cd696c0bcdceb0 100644
 --- a/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java
 +++ b/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java
 @@ -5,6 +5,7 @@ import com.infernalsuite.aswm.ChunkPos;
@@ -137,6 +137,6 @@ index 03f0a5c88a6b2d28a5a69649fc1295b51aaf879f..fe67f7d920f0599e642493adfdec5fce
 +
 +    @Override
 +    public @NotNull PersistentDataContainer getPersistentDataContainer() {
-+        return null;
++        return this.extraPDC;
 +    }
  }


### PR DESCRIPTION
This PR attempts to add PDC capabilities to SlimeWorld. It works by directly modifying the extra NBT tag in every slime world.
Please take a look at https://github.com/kyngs/ASP-PDCTest/tree/pr83 for an example of how one would use it.

~~While this implementation is finished, there's one big caveat, it does not support complex PDC tags (inserting a PDC into a PDC). Why? Because it cannot be achieved without casting the PDC API into the relevant implementation. Here are a few options:~~ Resolved in latest commit

1. Leave it as-is without support for complex tags
2. Do it the CraftBukkit way:
CraftBukkit just simply casts the PDC into CraftPersistentDataContainer. See the end of CraftPersistentDataTypeRegistry#createAdapter for reference. Doing this in our case would make support for PDC in SkeletonSlimeWorld impossible. 
3. Allow only passing of FlowPersistentDataContainers
I imagine this could be done quite easily but it wouldn't allow the user to directly pass PDCs obtained from CB's entities into SlimeWorld's PDC.
4. Merge options 2. and 3.