### PR TITLE
v12 SRF (per-chunk PDC support, no double-compression); fix bad bug causing chunks go poof.

### DIFF
--- a/SLIME_FORMAT
+++ b/SLIME_FORMAT
@@ -1,7 +1,7 @@
 -------------------------------------
 “Slime” file format
 2 bytes - magic = 0xB10B
-1 byte (ubyte) - version, current = 0x0B
+1 byte (ubyte) - version, current = 0x0C
 4 bytes (int) - world version (see version list below)
 4 bytes (int) - compressed chunks size
 4 bytes (int) - uncompressed chunks size
@@ -10,7 +10,7 @@
 
 4 bytes (int) - compressed “extra” size
 4 bytes (int) - uncompressed “extra” size
-[depends] - compound tag compressed using zstd
+[depends] - extra compound tag compressed using zstd (used for PDC, and/or custom data)
 -------------------------------------
 
 Custom chunk format
@@ -31,19 +31,17 @@ Custom chunk format
 4 bytes (int) - heightmaps size
   <array of heightmap nbt compounds>
     same format as mc, uncompressed
-4 bytes (int) - compressed tile entities size
-4 bytes (int) - uncompressed tile entities size
+4 bytes (int) - tile entities size
   <array of tile entity nbt compounds>
     Same format as mc
     inside an nbt list named “tiles”, in a global compound, no gzip anywhere
-    compressed using zstd
-4 bytes (int) compressed entities size
-4 bytes (int) uncompressed entities size
+    uncompressed
+4 bytes (int) entities size
   <array of entity nbt compounds>
     Same format as mc EXCEPT optional “CustomId”
     inside an nbt list named “entities”, in a global compound
     Compressed using zstd
-
+[depends] - compound tag uncompressed (used for PDC, and/or custom data)
 -------------------------------------
 
 World version list:
@@ -69,3 +67,4 @@ Version history:
  - v9: Fix issue with biomes size, causing old worlds to be corrupted
  - v10: Use minecraft version id, remove legacy version artifacts
  - v11: Move entities and tile entities into the chunk structure
+ - v12: Add support for chunk-based PDC

--- a/api/src/main/java/com/infernalsuite/aswm/api/utils/SlimeFormat.java
+++ b/api/src/main/java/com/infernalsuite/aswm/api/utils/SlimeFormat.java
@@ -9,5 +9,5 @@ public class SlimeFormat {
     public static final byte[] SLIME_HEADER = new byte[] { -79, 11 };
 
     /** Latest version of the SRF that SWM supports **/
-    public static final byte SLIME_VERSION = 11;
+    public static final byte SLIME_VERSION = 12;
 }

--- a/api/src/main/java/com/infernalsuite/aswm/api/world/SlimeChunk.java
+++ b/api/src/main/java/com/infernalsuite/aswm/api/world/SlimeChunk.java
@@ -53,4 +53,17 @@ public interface SlimeChunk {
      */
     List<CompoundTag> getEntities();
 
+    /**
+     * Returns the extra data of the chunk.
+     * Inside this {@link CompoundTag}
+     * can be stored any information to then be retrieved later, as it's
+     * saved alongside the chunk data.
+     * <br>
+     * <b>Beware, a compound tag under the key "ChunkBukkitValues" will be stored here.
+     * It is used for storing chunk-based Bukkit PDC. Do not overwrite it.</b>
+     *
+     * @return A {@link CompoundTag} containing the extra data of the chunk,
+     */
+    CompoundTag getExtraData();
+
 }

--- a/core/src/main/java/com/infernalsuite/aswm/serialization/anvil/AnvilWorldReader.java
+++ b/core/src/main/java/com/infernalsuite/aswm/serialization/anvil/AnvilWorldReader.java
@@ -383,7 +383,7 @@ public class AnvilWorldReader implements SlimeWorldReader<File> {
 
         var extraTag = new CompoundTag("", new CompoundMap());
 
-        extraTag.getValue().put(compound.getValue().get("ChunkBukkitValues")); // An attempt to migrate PDC from the anvil to the slime format.
+        extraTag.getValue().put(compound.getValue().get("ChunkBukkitValues")); // Attempt to Migrate PDC from Anvil format to Slime format.
 
         for (SlimeChunkSection section : sectionArray) {
             if (section != null) { // Chunk isn't empty

--- a/core/src/main/java/com/infernalsuite/aswm/serialization/anvil/AnvilWorldReader.java
+++ b/core/src/main/java/com/infernalsuite/aswm/serialization/anvil/AnvilWorldReader.java
@@ -381,9 +381,13 @@ public class AnvilWorldReader implements SlimeWorldReader<File> {
             sectionArray[index - minSectionY] = new SlimeChunkSectionSkeleton(/*paletteTag, blockStatesArray,*/ blockStatesTag, biomeTag, blockLightArray, skyLightArray);
         }
 
+        var extraTag = new CompoundTag("", new CompoundMap());
+
+        extraTag.getValue().put(compound.getValue().get("ChunkBukkitValues")); // An attempt to migrate PDC from the anvil to the slime format.
+
         for (SlimeChunkSection section : sectionArray) {
             if (section != null) { // Chunk isn't empty
-                return new SlimeChunkSkeleton(chunkX, chunkZ, sectionArray, heightMapsCompound, tileEntities, entities);
+                return new SlimeChunkSkeleton(chunkX, chunkZ, sectionArray, heightMapsCompound, tileEntities, entities, extraTag);
             }
         }
 

--- a/core/src/main/java/com/infernalsuite/aswm/serialization/anvil/AnvilWorldReader.java
+++ b/core/src/main/java/com/infernalsuite/aswm/serialization/anvil/AnvilWorldReader.java
@@ -381,7 +381,7 @@ public class AnvilWorldReader implements SlimeWorldReader<File> {
             sectionArray[index - minSectionY] = new SlimeChunkSectionSkeleton(/*paletteTag, blockStatesArray,*/ blockStatesTag, biomeTag, blockLightArray, skyLightArray);
         }
 
-        var extraTag = new CompoundTag("", new CompoundMap());
+        CompoundTag extraTag = new CompoundTag("", new CompoundMap());
 
         extraTag.getValue().put(compound.getValue().get("ChunkBukkitValues")); // Attempt to Migrate PDC from Anvil format to Slime format.
 

--- a/core/src/main/java/com/infernalsuite/aswm/serialization/slime/SlimeSerializer.java
+++ b/core/src/main/java/com/infernalsuite/aswm/serialization/slime/SlimeSerializer.java
@@ -12,6 +12,8 @@ import com.infernalsuite.aswm.api.world.SlimeChunk;
 import com.infernalsuite.aswm.api.world.SlimeChunkSection;
 import com.infernalsuite.aswm.api.world.SlimeWorld;
 import com.infernalsuite.aswm.api.world.properties.SlimePropertyMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -20,6 +22,8 @@ import java.nio.ByteOrder;
 import java.util.*;
 
 public class SlimeSerializer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SlimeSerializer.class);
 
     public static byte[] serialize(SlimeWorld world) {
         CompoundTag extraData = world.getExtraData();
@@ -78,7 +82,7 @@ public class SlimeSerializer {
             if (!ChunkPruner.canBePruned(world, chunk)) {
                 emptyChunks.add(chunk);
             } else {
-                System.out.println("PRUNED: " + chunk);
+                LOGGER.info("PRUNED: " + chunk);
             }
         }
 
@@ -142,7 +146,7 @@ public class SlimeSerializer {
             // Extra Tag
             {
                 if (chunk.getExtraData() == null) {
-                    System.err.println("Chunk at " + chunk.getX() + ", " + chunk.getZ() + " from world " + world.getName() + " has no extra data! When deserialized, this chunk will have an empty extra data tag!");
+                    LOGGER.warn("Chunk at " + chunk.getX() + ", " + chunk.getZ() + " from world " + world.getName() + " has no extra data! When deserialized, this chunk will have an empty extra data tag!");
                 }
                 byte[] extra = serializeCompoundTag(chunk.getExtraData());
 

--- a/core/src/main/java/com/infernalsuite/aswm/serialization/slime/SlimeSerializer.java
+++ b/core/src/main/java/com/infernalsuite/aswm/serialization/slime/SlimeSerializer.java
@@ -141,6 +141,9 @@ public class SlimeSerializer {
 
             // Extra Tag
             {
+                if (chunk.getExtraData() == null) {
+                    System.err.println("Chunk at " + chunk.getX() + ", " + chunk.getZ() + " from world " + world.getName() + " has no extra data! When deserialized, this chunk will have an empty extra data tag!");
+                }
                 byte[] extra = serializeCompoundTag(chunk.getExtraData());
 
                 outStream.writeInt(extra.length);

--- a/core/src/main/java/com/infernalsuite/aswm/serialization/slime/SlimeSerializer.java
+++ b/core/src/main/java/com/infernalsuite/aswm/serialization/slime/SlimeSerializer.java
@@ -127,21 +127,25 @@ public class SlimeSerializer {
             ListTag<CompoundTag> tileEntitiesNbtList = new ListTag<>("tileEntities", TagType.TAG_COMPOUND, chunk.getTileEntities());
             CompoundTag tileEntitiesCompound = new CompoundTag("", new CompoundMap(Collections.singletonList(tileEntitiesNbtList)));
             byte[] tileEntitiesData = serializeCompoundTag(tileEntitiesCompound);
-            byte[] compressedTileEntitiesData = Zstd.compress(tileEntitiesData);
 
-            outStream.writeInt(compressedTileEntitiesData.length);
             outStream.writeInt(tileEntitiesData.length);
-            outStream.write(compressedTileEntitiesData);
+            outStream.write(tileEntitiesData);
 
             // Entities
             ListTag<CompoundTag> entitiesNbtList = new ListTag<>("entities", TagType.TAG_COMPOUND, chunk.getEntities());
             CompoundTag entitiesCompound = new CompoundTag("", new CompoundMap(Collections.singletonList(entitiesNbtList)));
             byte[] entitiesData = serializeCompoundTag(entitiesCompound);
-            byte[] compressedEntitiesData = Zstd.compress(entitiesData);
 
-            outStream.writeInt(compressedEntitiesData.length);
             outStream.writeInt(entitiesData.length);
-            outStream.write(compressedEntitiesData);
+            outStream.write(entitiesData);
+
+            // Extra Tag
+            {
+                byte[] extra = serializeCompoundTag(chunk.getExtraData());
+
+                outStream.writeInt(extra.length);
+                outStream.write(extra);
+            }
         }
 
         return outByteStream.toByteArray();

--- a/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/SlimeWorldReaderRegistry.java
+++ b/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/SlimeWorldReaderRegistry.java
@@ -7,6 +7,7 @@ import com.infernalsuite.aswm.api.utils.SlimeFormat;
 import com.infernalsuite.aswm.api.world.SlimeWorld;
 import com.infernalsuite.aswm.api.world.properties.SlimePropertyMap;
 import com.infernalsuite.aswm.serialization.slime.reader.impl.v11.v11WorldFormat;
+import com.infernalsuite.aswm.serialization.slime.reader.impl.v12.v12WorldFormat;
 import com.infernalsuite.aswm.serialization.slime.reader.impl.v19.v1_9WorldFormat;
 import com.infernalsuite.aswm.serialization.slime.reader.impl.v10.v10WorldFormat;
 
@@ -25,6 +26,7 @@ public class SlimeWorldReaderRegistry {
         register(v1_9WorldFormat.FORMAT, 1, 2, 3, 4, 5, 6, 7, 8, 9);
         register(v10WorldFormat.FORMAT, 10);
         register(v11WorldFormat.FORMAT, 11);
+        register(v12WorldFormat.FORMAT, 12);
     }
 
     private static void register(VersionedByteSlimeWorldReader<SlimeWorld> format, int... bytes) {

--- a/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v10/v10SlimeWorldDeSerializer.java
+++ b/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v10/v10SlimeWorldDeSerializer.java
@@ -167,7 +167,7 @@ class v10SlimeWorldDeSerializer implements VersionedByteSlimeWorldReader<SlimeWo
                 }
 
                 chunkMap.put(new ChunkPos(x, z),
-                        new SlimeChunkSkeleton(x, z, chunkSectionArray, heightMaps, new ArrayList<>(), new ArrayList<>())
+                        new SlimeChunkSkeleton(x, z, chunkSectionArray, heightMaps, new ArrayList<>(), new ArrayList<>(), new CompoundTag("", new CompoundMap()))
                 );
             }
         }

--- a/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v12/v12SlimeWorldDeSerializer.java
+++ b/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v12/v12SlimeWorldDeSerializer.java
@@ -128,12 +128,15 @@ public class v12SlimeWorldDeSerializer implements VersionedByteSlimeWorldReader<
             @SuppressWarnings("unchecked")
             List<CompoundTag> serializedEntities = ((ListTag<CompoundTag>) entitiesCompound.getValue().get("entities")).getValue();
 
+
             // Extra Tag
             byte[] rawExtra = read(chunkData);
             CompoundTag extra = readCompound(rawExtra);
             // If the extra tag is empty, the serializer will save it as null.
             // So if we deserialize a null extra tag, we will assume it was empty.
-            if (extra == null) extra = new CompoundTag("", new CompoundMap());
+            if (extra == null) {
+                extra = new CompoundTag("", new CompoundMap());
+            }
 
             chunkMap.put(new ChunkPos(x, z),
                     new SlimeChunkSkeleton(x, z, chunkSections, heightMaps, serializedTileEntities, serializedEntities, extra));
@@ -159,7 +162,9 @@ public class v12SlimeWorldDeSerializer implements VersionedByteSlimeWorldReader<
     }
 
     private static CompoundTag readCompound(byte[] tagBytes) throws IOException {
-        if (tagBytes.length == 0) return null;
+        if (tagBytes.length == 0) {
+            return null;
+        }
 
         NBTInputStream nbtStream = new NBTInputStream(new ByteArrayInputStream(tagBytes), NBTInputStream.NO_COMPRESSION, ByteOrder.BIG_ENDIAN);
         return (CompoundTag) nbtStream.readTag();

--- a/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v12/v12SlimeWorldDeSerializer.java
+++ b/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v12/v12SlimeWorldDeSerializer.java
@@ -131,6 +131,9 @@ public class v12SlimeWorldDeSerializer implements VersionedByteSlimeWorldReader<
             // Extra Tag
             var rawExtra = read(chunkData);
             var extra = readCompound(rawExtra);
+            // If the extra tag is empty, the serializer will save it as null.
+            // So if we deserialize a null extra tag, we will assume it was empty.
+            if (extra == null) extra = new CompoundTag("", new CompoundMap());
 
             chunkMap.put(new ChunkPos(x, z),
                     new SlimeChunkSkeleton(x, z, chunkSections, heightMaps, serializedTileEntities, serializedEntities, extra));

--- a/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v12/v12SlimeWorldDeSerializer.java
+++ b/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v12/v12SlimeWorldDeSerializer.java
@@ -114,7 +114,7 @@ public class v12SlimeWorldDeSerializer implements VersionedByteSlimeWorldReader<
 
             // Tile Entities
 
-            var tileEntities = read(chunkData);
+            byte[] tileEntities = read(chunkData);
 
             CompoundTag tileEntitiesCompound = readCompound(tileEntities);
             @SuppressWarnings("unchecked")
@@ -122,15 +122,15 @@ public class v12SlimeWorldDeSerializer implements VersionedByteSlimeWorldReader<
 
             // Entities
 
-            var entities = read(chunkData);
+            byte[] entities = read(chunkData);
 
             CompoundTag entitiesCompound = readCompound(entities);
             @SuppressWarnings("unchecked")
             List<CompoundTag> serializedEntities = ((ListTag<CompoundTag>) entitiesCompound.getValue().get("entities")).getValue();
 
             // Extra Tag
-            var rawExtra = read(chunkData);
-            var extra = readCompound(rawExtra);
+            byte[] rawExtra = read(chunkData);
+            CompoundTag extra = readCompound(rawExtra);
             // If the extra tag is empty, the serializer will save it as null.
             // So if we deserialize a null extra tag, we will assume it was empty.
             if (extra == null) extra = new CompoundTag("", new CompoundMap());

--- a/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v12/v12SlimeWorldDeSerializer.java
+++ b/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v12/v12SlimeWorldDeSerializer.java
@@ -1,4 +1,4 @@
-package com.infernalsuite.aswm.serialization.slime.reader.impl.v11;
+package com.infernalsuite.aswm.serialization.slime.reader.impl.v12;
 
 import com.flowpowered.nbt.CompoundMap;
 import com.flowpowered.nbt.CompoundTag;
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-public class v11SlimeWorldDeSerializer implements VersionedByteSlimeWorldReader<SlimeWorld> {
+public class v12SlimeWorldDeSerializer implements VersionedByteSlimeWorldReader<SlimeWorld> {
 
     public static final int ARRAY_SIZE = 16 * 16 * 16 / (8 / 4);
 
@@ -114,32 +114,26 @@ public class v11SlimeWorldDeSerializer implements VersionedByteSlimeWorldReader<
 
             // Tile Entities
 
-            int compressedTileEntitiesLength = chunkData.readInt();
-            int decompressedTileEntitiesLength = chunkData.readInt();
-            byte[] compressedTileEntitiesData = new byte[compressedTileEntitiesLength];
-            byte[] decompressedTileEntitiesData = new byte[decompressedTileEntitiesLength];
-            chunkData.read(compressedTileEntitiesData);
-            Zstd.decompress(decompressedTileEntitiesData, compressedTileEntitiesData);
+            var tileEntities = read(chunkData);
 
-            CompoundTag tileEntitiesCompound = readCompound(decompressedTileEntitiesData);
+            CompoundTag tileEntitiesCompound = readCompound(tileEntities);
             @SuppressWarnings("unchecked")
             List<CompoundTag> serializedTileEntities = ((ListTag<CompoundTag>) tileEntitiesCompound.getValue().get("tileEntities")).getValue();
 
             // Entities
 
-            int compressedEntitiesLength = chunkData.readInt();
-            int decompressedEntitiesLength = chunkData.readInt();
-            byte[] compressedEntitiesData = new byte[compressedEntitiesLength];
-            byte[] decompressedEntitiesData = new byte[decompressedEntitiesLength];
-            chunkData.read(compressedEntitiesData);
-            Zstd.decompress(decompressedEntitiesData, compressedEntitiesData);
+            var entities = read(chunkData);
 
-            CompoundTag entitiesCompound = readCompound(decompressedEntitiesData);
+            CompoundTag entitiesCompound = readCompound(entities);
             @SuppressWarnings("unchecked")
             List<CompoundTag> serializedEntities = ((ListTag<CompoundTag>) entitiesCompound.getValue().get("entities")).getValue();
 
+            // Extra Tag
+            var rawExtra = read(chunkData);
+            var extra = readCompound(rawExtra);
+
             chunkMap.put(new ChunkPos(x, z),
-                    new SlimeChunkSkeleton(x, z, chunkSections, heightMaps, serializedTileEntities, serializedEntities, new CompoundTag("", new CompoundMap())));
+                    new SlimeChunkSkeleton(x, z, chunkSections, heightMaps, serializedTileEntities, serializedEntities, extra));
         }
         return chunkMap;
     }
@@ -152,6 +146,13 @@ public class v11SlimeWorldDeSerializer implements VersionedByteSlimeWorldReader<
         stream.read(compressedData);
         Zstd.decompress(decompressedData, compressedData);
         return decompressedData;
+    }
+
+    private static byte[] read(DataInputStream stream) throws IOException {
+        int length = stream.readInt();
+        byte[] data = new byte[length];
+        stream.read(data);
+        return data;
     }
 
     private static CompoundTag readCompound(byte[] tagBytes) throws IOException {

--- a/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v12/v12WorldFormat.java
+++ b/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v12/v12WorldFormat.java
@@ -1,0 +1,10 @@
+package com.infernalsuite.aswm.serialization.slime.reader.impl.v12;
+
+import com.infernalsuite.aswm.api.world.SlimeWorld;
+import com.infernalsuite.aswm.serialization.slime.reader.impl.SimpleWorldFormat;
+
+public interface v12WorldFormat {
+
+    SimpleWorldFormat<SlimeWorld> FORMAT = new SimpleWorldFormat<>(data -> data, new v12SlimeWorldDeSerializer());
+
+}

--- a/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v19/v1_9SlimeConverter.java
+++ b/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v19/v1_9SlimeConverter.java
@@ -1,5 +1,7 @@
 package com.infernalsuite.aswm.serialization.slime.reader.impl.v19;
 
+import com.flowpowered.nbt.CompoundMap;
+import com.flowpowered.nbt.CompoundTag;
 import com.infernalsuite.aswm.ChunkPos;
 import com.infernalsuite.aswm.serialization.SlimeWorldReader;
 import com.infernalsuite.aswm.skeleton.SkeletonSlimeWorld;
@@ -61,7 +63,8 @@ class v1_9SlimeConverter implements SlimeWorldReader<v1_9SlimeWorld> {
                     sections,
                     slimeChunk.heightMap,
                     slimeChunk.tileEntities,
-                    slimeChunk.entities
+                    slimeChunk.entities,
+                    new CompoundTag("", new CompoundMap())
             ));
         }
 

--- a/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonCloning.java
+++ b/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonCloning.java
@@ -71,7 +71,8 @@ public class SkeletonCloning {
                             copied,
                             chunk.getHeightMaps().clone(),
                             deepClone(chunk.getTileEntities()),
-                            deepClone(chunk.getEntities())
+                            deepClone(chunk.getEntities()),
+                            chunk.getExtraData().clone()
                     ));
         }
 

--- a/core/src/main/java/com/infernalsuite/aswm/skeleton/SlimeChunkSkeleton.java
+++ b/core/src/main/java/com/infernalsuite/aswm/skeleton/SlimeChunkSkeleton.java
@@ -9,7 +9,9 @@ import java.util.List;
 public record SlimeChunkSkeleton(int x, int z, SlimeChunkSection[] sections,
                                  CompoundTag heightMap,
                                  List<CompoundTag> blockEntities,
-                                 List<CompoundTag> entities) implements SlimeChunk {
+                                 List<CompoundTag> entities,
+                                 CompoundTag extra) implements SlimeChunk {
+
     @Override
     public int getX() {
         return this.x;
@@ -38,5 +40,10 @@ public record SlimeChunkSkeleton(int x, int z, SlimeChunkSection[] sections,
     @Override
     public List<CompoundTag> getEntities() {
         return this.entities;
+    }
+
+    @Override
+    public CompoundTag getExtraData() {
+        return this.extra;
     }
 }

--- a/patches/server/0008-Fix-entity-loading.patch
+++ b/patches/server/0008-Fix-entity-loading.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix entity loading
 
 
 diff --git a/src/main/java/com/infernalsuite/aswm/level/ChunkDataLoadTask.java b/src/main/java/com/infernalsuite/aswm/level/ChunkDataLoadTask.java
-index c32d52c68188dc1eb7feeac364cdc4aded1c4574..e74d9edca5d5166502f39e617939e0c7038f200a 100644
+index c32d52c68188dc1eb7feeac364cdc4aded1c4574..8485296594c01edcaef271fc37bf2c70932f4986 100644
 --- a/src/main/java/com/infernalsuite/aswm/level/ChunkDataLoadTask.java
 +++ b/src/main/java/com/infernalsuite/aswm/level/ChunkDataLoadTask.java
 @@ -1,12 +1,13 @@
@@ -40,7 +40,7 @@ index c32d52c68188dc1eb7feeac364cdc4aded1c4574..e74d9edca5d5166502f39e617939e0c7
      }
  
      protected ChunkAccess runOnMain(final SlimeChunk data) {
-@@ -73,6 +73,10 @@ public final class ChunkDataLoadTask implements CommonLoadTask {
+@@ -73,8 +73,12 @@ public final class ChunkDataLoadTask implements CommonLoadTask {
              //                }
  
              LevelChunk chunk = this.world.slimeInstance.promote(chunkX, chunkZ, data);
@@ -49,10 +49,13 @@ index c32d52c68188dc1eb7feeac364cdc4aded1c4574..e74d9edca5d5166502f39e617939e0c7
 +                data.getEntities().stream().map(flowTag -> (CompoundTag) Converter.convertTag(flowTag)).forEach(protoChunk::addEntity);
 +            }
  
-             return new ImposterProtoChunk(chunk, false);
+-            return new ImposterProtoChunk(chunk, false);
++            return protoChunk;
          } catch (final ThreadDeath death) {
+             throw death;
+         } catch (final Throwable thr2) {
 diff --git a/src/main/java/com/infernalsuite/aswm/level/SlimeChunkConverter.java b/src/main/java/com/infernalsuite/aswm/level/SlimeChunkConverter.java
-index 91a7f41db47c7df3ecc301e0827a1d07305f604e..276c48a4e9d10fd3124ce29586d3b2ef8c3a1727 100644
+index 91a7f41db47c7df3ecc301e0827a1d07305f604e..95c83e974eeec44664aedb02a9fc7bfb02c35f78 100644
 --- a/src/main/java/com/infernalsuite/aswm/level/SlimeChunkConverter.java
 +++ b/src/main/java/com/infernalsuite/aswm/level/SlimeChunkConverter.java
 @@ -15,6 +15,8 @@ import net.minecraft.core.Holder;
@@ -72,9 +75,22 @@ index 91a7f41db47c7df3ecc301e0827a1d07305f604e..276c48a4e9d10fd3124ce29586d3b2ef
 +            List<CompoundTag> entities = chunk.getEntities();
 +
 +            if (entities != null) {
-+                instance.addLegacyChunkEntities(EntityType.loadEntitiesRecursive(entities.stream()
-+                        .map(flowTag -> (net.minecraft.nbt.CompoundTag) Converter.convertTag(flowTag)).toList(), instance), nmsChunk.getPos());
++                net.minecraft.server.level.ChunkMap.postLoadProtoChunk(instance, entities.stream()
++                        .map(flowTag -> (net.minecraft.nbt.CompoundTag) Converter.convertTag(flowTag)).toList(), nmsChunk.getPos());
 +            }
          };
  
          LevelChunkTicks<Block> blockLevelChunkTicks = new LevelChunkTicks<>();
+diff --git a/src/main/java/io/papermc/paper/chunk/system/scheduling/NewChunkHolder.java b/src/main/java/io/papermc/paper/chunk/system/scheduling/NewChunkHolder.java
+index b66a7d4aab887309579154815a0d4abf9de506b0..1654d7ec66e5077810494992e3c56fb692301269 100644
+--- a/src/main/java/io/papermc/paper/chunk/system/scheduling/NewChunkHolder.java
++++ b/src/main/java/io/papermc/paper/chunk/system/scheduling/NewChunkHolder.java
+@@ -112,7 +112,7 @@ public final class NewChunkHolder {
+         }
+ 
+         if (!transientChunk) {
+-            if (entityChunk != null) {
++            if (!(this.world instanceof com.infernalsuite.aswm.level.SlimeLevelInstance) && entityChunk != null) {
+                 final List<Entity> entities = EntityStorage.readEntities(this.world, entityChunk);
+ 
+                 this.world.getEntityLookup().addEntityChunkEntities(entities, new ChunkPos(this.chunkX, this.chunkZ));

--- a/patches/server/0008-Fix-entity-loading.patch
+++ b/patches/server/0008-Fix-entity-loading.patch
@@ -55,7 +55,7 @@ index c32d52c68188dc1eb7feeac364cdc4aded1c4574..8485296594c01edcaef271fc37bf2c70
              throw death;
          } catch (final Throwable thr2) {
 diff --git a/src/main/java/com/infernalsuite/aswm/level/SlimeChunkConverter.java b/src/main/java/com/infernalsuite/aswm/level/SlimeChunkConverter.java
-index 91a7f41db47c7df3ecc301e0827a1d07305f604e..95c83e974eeec44664aedb02a9fc7bfb02c35f78 100644
+index 91a7f41db47c7df3ecc301e0827a1d07305f604e..27af3aa6ba8ffb100a6b1b50ba584e65c4aee86a 100644
 --- a/src/main/java/com/infernalsuite/aswm/level/SlimeChunkConverter.java
 +++ b/src/main/java/com/infernalsuite/aswm/level/SlimeChunkConverter.java
 @@ -15,6 +15,8 @@ import net.minecraft.core.Holder;
@@ -67,20 +67,63 @@ index 91a7f41db47c7df3ecc301e0827a1d07305f604e..95c83e974eeec44664aedb02a9fc7bfb
  import net.minecraft.world.level.ChunkPos;
  import net.minecraft.world.level.biome.Biome;
  import net.minecraft.world.level.biome.Biomes;
-@@ -127,6 +129,13 @@ public class SlimeChunkConverter {
-                     }
-                 }
-             }
-+
+@@ -106,26 +108,11 @@ public class SlimeChunkConverter {
+ 
+ 
+         LevelChunk.PostLoadProcessor loadEntities = (nmsChunk) -> {
 +            List<CompoundTag> entities = chunk.getEntities();
-+
+ 
+-            // TODO
+-            // Load tile entities
+-            List<CompoundTag> tileEntities = chunk.getTileEntities();
+-
+-            if (tileEntities != null) {
+-                for (CompoundTag tag : tileEntities) {
+-                    Optional<String> type = tag.getStringValue("id");
+-
+-                    // Sometimes null tile entities are saved
+-                    if (type.isPresent()) {
+-                        BlockPos blockPosition = new BlockPos(tag.getIntValue("x").get(), tag.getIntValue("y").get(), tag.getIntValue("z").get());
+-                        BlockState blockData = nmsChunk.getBlockState(blockPosition);
+-                        BlockEntity entity = BlockEntity.loadStatic(blockPosition, blockData, (net.minecraft.nbt.CompoundTag) Converter.convertTag(tag));
+-
+-                        if (entity != null) {
+-                            nmsChunk.setBlockEntity(entity);
+-                        }
+-                    }
+-                }
 +            if (entities != null) {
 +                net.minecraft.server.level.ChunkMap.postLoadProtoChunk(instance, entities.stream()
 +                        .map(flowTag -> (net.minecraft.nbt.CompoundTag) Converter.convertTag(flowTag)).toList(), nmsChunk.getPos());
-+            }
+             }
          };
  
-         LevelChunkTicks<Block> blockLevelChunkTicks = new LevelChunkTicks<>();
+@@ -133,6 +120,25 @@ public class SlimeChunkConverter {
+         LevelChunkTicks<Fluid> fluidLevelChunkTicks = new LevelChunkTicks<>();
+         SlimeChunkLevel nmsChunk = new SlimeChunkLevel(instance, pos, UpgradeData.EMPTY, blockLevelChunkTicks, fluidLevelChunkTicks, 0L, sections, loadEntities, null);
+ 
++        List<CompoundTag> tileEntities = chunk.getTileEntities();
++
++        if (tileEntities != null) {
++            for (CompoundTag tag : tileEntities) {
++                Optional<String> type = tag.getStringValue("id");
++
++                // Sometimes null tile entities are saved
++                if (type.isPresent()) {
++                    BlockPos blockPosition = new BlockPos(tag.getIntValue("x").get(), tag.getIntValue("y").get(), tag.getIntValue("z").get());
++                    BlockState blockData = nmsChunk.getBlockState(blockPosition);
++                    BlockEntity entity = BlockEntity.loadStatic(blockPosition, blockData, (net.minecraft.nbt.CompoundTag) Converter.convertTag(tag));
++
++                    if (entity != null) {
++                        nmsChunk.setBlockEntity(entity);
++                    }
++                }
++            }
++        }
++
+         // Height Maps
+         EnumSet<Heightmap.Types> heightMapTypes = nmsChunk.getStatus().heightmapsAfter();
+         CompoundMap heightMaps = chunk.getHeightMaps().getValue();
 diff --git a/src/main/java/io/papermc/paper/chunk/system/scheduling/NewChunkHolder.java b/src/main/java/io/papermc/paper/chunk/system/scheduling/NewChunkHolder.java
 index b66a7d4aab887309579154815a0d4abf9de506b0..1654d7ec66e5077810494992e3c56fb692301269 100644
 --- a/src/main/java/io/papermc/paper/chunk/system/scheduling/NewChunkHolder.java

--- a/patches/server/0009-Remove-catch-throwable.patch
+++ b/patches/server/0009-Remove-catch-throwable.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Remove catch throwable
 
 
 diff --git a/src/main/java/com/infernalsuite/aswm/level/ChunkDataLoadTask.java b/src/main/java/com/infernalsuite/aswm/level/ChunkDataLoadTask.java
-index e74d9edca5d5166502f39e617939e0c7038f200a..65642a9bde0fffc6531604026dd957fd268b6642 100644
+index 8485296594c01edcaef271fc37bf2c70932f4986..f9ac1efca06d8debbb7894160c3e67fd23440ebb 100644
 --- a/src/main/java/com/infernalsuite/aswm/level/ChunkDataLoadTask.java
 +++ b/src/main/java/com/infernalsuite/aswm/level/ChunkDataLoadTask.java
 @@ -48,7 +48,7 @@ public final class ChunkDataLoadTask implements CommonLoadTask {
@@ -20,7 +20,7 @@ index e74d9edca5d5166502f39e617939e0c7038f200a..65642a9bde0fffc6531604026dd957fd
 @@ -79,10 +79,8 @@ public final class ChunkDataLoadTask implements CommonLoadTask {
              }
  
-             return new ImposterProtoChunk(chunk, false);
+             return protoChunk;
 -        } catch (final ThreadDeath death) {
 -            throw death;
 -        } catch (final Throwable thr2) {

--- a/patches/server/0011-Add-v12-chunk-pdc-and-extra-nbt.-Fix-double-compress.patch
+++ b/patches/server/0011-Add-v12-chunk-pdc-and-extra-nbt.-Fix-double-compress.patch
@@ -1,0 +1,173 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: kyngs <kyngs@users.noreply.github.com>
+Date: Tue, 19 Dec 2023 21:47:15 +0100
+Subject: [PATCH] Add v12, chunk pdc and extra nbt. Fix double compression on
+ tile entities and entities. Fix horrible bug which made chunks go poof.
+
+
+diff --git a/src/main/java/com/infernalsuite/aswm/SimpleDataFixerConverter.java b/src/main/java/com/infernalsuite/aswm/SimpleDataFixerConverter.java
+index 1a4be97069f01a82deadd26a94e86dbebe0e47a0..ca4a80e7b5c73f9669a717adc46b2e9b8c1f48b6 100644
+--- a/src/main/java/com/infernalsuite/aswm/SimpleDataFixerConverter.java
++++ b/src/main/java/com/infernalsuite/aswm/SimpleDataFixerConverter.java
+@@ -70,11 +70,12 @@ class SimpleDataFixerConverter implements SlimeWorldReader<SlimeWorld> {
+ 
+             chunks.put(chunkPos, new SlimeChunkSkeleton(
+                     chunk.getX(),
+-                    chunk.getX(),
++                    chunk.getZ(),
+                     sections,
+                     chunk.getHeightMaps(),
+                     blockEntities,
+-                    entities
++                    entities,
++                    chunk.getExtraData()
+             ));
+ 
+         }
+diff --git a/src/main/java/com/infernalsuite/aswm/level/NMSSlimeChunk.java b/src/main/java/com/infernalsuite/aswm/level/NMSSlimeChunk.java
+index f1db2fe121bb3aabfad727a8133b645524b8f19a..ad30e83670ca88f09fa7625fc52c224247410623 100644
+--- a/src/main/java/com/infernalsuite/aswm/level/NMSSlimeChunk.java
++++ b/src/main/java/com/infernalsuite/aswm/level/NMSSlimeChunk.java
+@@ -67,9 +67,11 @@ public class NMSSlimeChunk implements SlimeChunk {
+     }
+ 
+     private LevelChunk chunk;
++    private CompoundTag extra;
+ 
+-    public NMSSlimeChunk(LevelChunk chunk) {
++    public NMSSlimeChunk(LevelChunk chunk, SlimeChunk reference) {
+         this.chunk = chunk;
++        this.extra = reference == null ? new CompoundTag("", new CompoundMap()) : reference.getExtraData();
+     }
+ 
+     @Override
+@@ -192,6 +194,11 @@ public class NMSSlimeChunk implements SlimeChunk {
+         });
+     }
+ 
++    @Override
++    public CompoundTag getExtraData() {
++        return extra;
++    }
++
+     public LevelChunk getChunk() {
+         return chunk;
+     }
+diff --git a/src/main/java/com/infernalsuite/aswm/level/NMSSlimeWorld.java b/src/main/java/com/infernalsuite/aswm/level/NMSSlimeWorld.java
+index 9a27369c00345bbb94aa19f77687269dc94c0b0a..e0fc007bbc324f258a8bc7975fd8d95a2644f962 100644
+--- a/src/main/java/com/infernalsuite/aswm/level/NMSSlimeWorld.java
++++ b/src/main/java/com/infernalsuite/aswm/level/NMSSlimeWorld.java
+@@ -43,14 +43,14 @@ public class NMSSlimeWorld implements SlimeWorld {
+             return null;
+         }
+ 
+-        return new NMSSlimeChunk(chunk);
++        return new NMSSlimeChunk(chunk, memoryWorld.getChunk(x, z));
+     }
+ 
+     @Override
+     public Collection<SlimeChunk> getChunkStorage() {
+         List<ChunkHolder> chunks = io.papermc.paper.chunk.system.ChunkSystem.getVisibleChunkHolders(this.instance); // Paper
+         return chunks.stream().map(ChunkHolder::getFullChunkNow).filter(Objects::nonNull)
+-                .map(NMSSlimeChunk::new)
++                .map((chunkLevel) -> new NMSSlimeChunk(chunkLevel, memoryWorld.getChunk(chunkLevel.getPos().x, chunkLevel.getPos().z))) // This sucks, is there a better way?
+                 .collect(Collectors.toList());
+     }
+ 
+diff --git a/src/main/java/com/infernalsuite/aswm/level/SafeNmsChunkWrapper.java b/src/main/java/com/infernalsuite/aswm/level/SafeNmsChunkWrapper.java
+index b20a037679182e3c4a8bf31f084078f6d7e4ff46..e449b3eebe0d245a2107a6d0018930d32dfc4976 100644
+--- a/src/main/java/com/infernalsuite/aswm/level/SafeNmsChunkWrapper.java
++++ b/src/main/java/com/infernalsuite/aswm/level/SafeNmsChunkWrapper.java
+@@ -62,6 +62,15 @@ public class SafeNmsChunkWrapper implements SlimeChunk {
+         return this.wrapper.getEntities();
+     }
+ 
++    @Override
++    public CompoundTag getExtraData() {
++        if (shouldDefaultBackToSlimeChunk()) {
++            return this.safety.getExtraData();
++        }
++
++        return this.wrapper.getExtraData();
++    }
++
+     /*
+ Slime chunks can still be requested but not actually loaded, this caused
+ some things to not properly save because they are not "loaded" into the chunk.
+diff --git a/src/main/java/com/infernalsuite/aswm/level/SlimeChunkConverter.java b/src/main/java/com/infernalsuite/aswm/level/SlimeChunkConverter.java
+index 276c48a4e9d10fd3124ce29586d3b2ef8c3a1727..9302b8bba83840eff921f0dc000344c41631a65b 100644
+--- a/src/main/java/com/infernalsuite/aswm/level/SlimeChunkConverter.java
++++ b/src/main/java/com/infernalsuite/aswm/level/SlimeChunkConverter.java
+@@ -168,6 +168,13 @@ public class SlimeChunkConverter {
+             Heightmap.primeHeightmaps(nmsChunk, unsetHeightMaps);
+         }
+ 
++        var nmsExtraData = (net.minecraft.nbt.CompoundTag) Converter.convertTag(chunk.getExtraData());
++
++        // Attempt to read PDC from the extra tag
++        if (nmsExtraData.get("ChunkBukkitValues") != null) {
++            nmsChunk.persistentDataContainer.putAll(nmsExtraData.getCompound("ChunkBukkitValues"));
++        }
++
+         return nmsChunk;
+     }
+ }
+\ No newline at end of file
+diff --git a/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java b/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java
+index 03f0a5c88a6b2d28a5a69649fc1295b51aaf879f..76913fab8da9509d86b8c685ad6078244257b7fc 100644
+--- a/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java
++++ b/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java
+@@ -83,11 +83,11 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
+             levelChunk = new SlimeChunkLevel(this.instance, pos, UpgradeData.EMPTY, blockLevelChunkTicks, fluidLevelChunkTicks,
+                     0L, null, null, null);
+ 
+-            chunk = new NMSSlimeChunk(levelChunk);
++            chunk = new NMSSlimeChunk(levelChunk, getChunk(x, z));
+ 
+         } else {
+             levelChunk = SlimeChunkConverter.deserializeSlimeChunk(this.instance, chunk);
+-            chunk = new SafeNmsChunkWrapper(new NMSSlimeChunk(levelChunk), chunk);
++            chunk = new SafeNmsChunkWrapper(new NMSSlimeChunk(levelChunk, chunk), chunk);
+         }
+         this.chunkStorage.put(new ChunkPos(x, z), chunk);
+ 
+@@ -100,7 +100,7 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
+         final int x = providedChunk.locX;
+         final int z = providedChunk.locZ;
+ 
+-        SlimeChunk chunk = new NMSSlimeChunk(providedChunk);
++        SlimeChunk chunk = new NMSSlimeChunk(providedChunk, getChunk(x, z));
+ 
+         if (FastChunkPruner.canBePruned(this.liveWorld, providedChunk)) {
+             this.chunkStorage.remove(new ChunkPos(x, z));
+@@ -109,7 +109,7 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
+ 
+         this.chunkStorage.put(new ChunkPos(x, z),
+                 new SlimeChunkSkeleton(chunk.getX(), chunk.getZ(), chunk.getSections(),
+-                        chunk.getHeightMaps(), chunk.getTileEntities(), chunk.getEntities()));
++                        chunk.getHeightMaps(), chunk.getTileEntities(), chunk.getEntities(), chunk.getExtraData()));
+     }
+ 
+     @Override
+@@ -222,13 +222,20 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
+                         continue;
+                     }
+ 
++                    // Serialize Bukkit Values (PDC)
++
++                    var flowTag = Converter.convertTag("ChunkBukkitValues", chunk.persistentDataContainer.toTagCompound());
++
++                    clonedChunk.getExtraData().getValue().put(flowTag);
++
+                     clonedChunk = new SlimeChunkSkeleton(
+                             clonedChunk.getX(),
+                             clonedChunk.getZ(),
+                             clonedChunk.getSections(),
+                             clonedChunk.getHeightMaps(),
+                             clonedChunk.getTileEntities(),
+-                            clonedChunk.getEntities()
++                            clonedChunk.getEntities(),
++                            clonedChunk.getExtraData()
+                     );
+                 }
+             }

--- a/patches/server/0012-Add-v12-chunk-pdc-and-extra-nbt.-Fix-double-compress.patch
+++ b/patches/server/0012-Add-v12-chunk-pdc-and-extra-nbt.-Fix-double-compress.patch
@@ -171,3 +171,19 @@ index 092dae1f9e68f1c395cd0f8151cd696c0bcdceb0..208339f93fbd078b89d4bbb24fd8f7d3
                      );
                  }
              }
+diff --git a/src/main/java/com/infernalsuite/aswm/level/SlimeLevelInstance.java b/src/main/java/com/infernalsuite/aswm/level/SlimeLevelInstance.java
+index 65b475b1292e01c918c1f8144599b5fa78688e97..67be177f92ff66074b6f0f0f82fce284ccb229a4 100644
+--- a/src/main/java/com/infernalsuite/aswm/level/SlimeLevelInstance.java
++++ b/src/main/java/com/infernalsuite/aswm/level/SlimeLevelInstance.java
+@@ -151,9 +151,9 @@ public class SlimeLevelInstance extends ServerLevel {
+             Bukkit.getLogger().log(Level.INFO, "Saving world " + this.slimeInstance.getName() + "...");
+             long start = System.currentTimeMillis();
+ 
+-            Bukkit.getLogger().log(Level.INFO, "CONVERTING NMS -> SKELETON");
++            //Bukkit.getLogger().log(Level.INFO, "CONVERTING NMS -> SKELETON");
+             SlimeWorld world = this.slimeInstance.getForSerialization();
+-            Bukkit.getLogger().log(Level.INFO, "CONVERTED TO SKELETON, PUSHING OFF-THREAD");
++            //Bukkit.getLogger().log(Level.INFO, "CONVERTED TO SKELETON, PUSHING OFF-THREAD");
+             return WORLD_SAVER_SERVICE.submit(() -> {
+                 try {
+                     byte[] serializedWorld = SlimeSerializer.serialize(world);

--- a/patches/server/0012-Add-v12-chunk-pdc-and-extra-nbt.-Fix-double-compress.patch
+++ b/patches/server/0012-Add-v12-chunk-pdc-and-extra-nbt.-Fix-double-compress.patch
@@ -95,10 +95,10 @@ index b20a037679182e3c4a8bf31f084078f6d7e4ff46..e449b3eebe0d245a2107a6d0018930d3
  Slime chunks can still be requested but not actually loaded, this caused
  some things to not properly save because they are not "loaded" into the chunk.
 diff --git a/src/main/java/com/infernalsuite/aswm/level/SlimeChunkConverter.java b/src/main/java/com/infernalsuite/aswm/level/SlimeChunkConverter.java
-index 276c48a4e9d10fd3124ce29586d3b2ef8c3a1727..9302b8bba83840eff921f0dc000344c41631a65b 100644
+index 27af3aa6ba8ffb100a6b1b50ba584e65c4aee86a..afa5804039d6b15c29f0ddc7d778b5b0b1d9dc6f 100644
 --- a/src/main/java/com/infernalsuite/aswm/level/SlimeChunkConverter.java
 +++ b/src/main/java/com/infernalsuite/aswm/level/SlimeChunkConverter.java
-@@ -168,6 +168,13 @@ public class SlimeChunkConverter {
+@@ -165,6 +165,13 @@ public class SlimeChunkConverter {
              Heightmap.primeHeightmaps(nmsChunk, unsetHeightMaps);
          }
  

--- a/patches/server/0012-Add-v12-chunk-pdc-and-extra-nbt.-Fix-double-compress.patch
+++ b/patches/server/0012-Add-v12-chunk-pdc-and-extra-nbt.-Fix-double-compress.patch
@@ -187,3 +187,16 @@ index 65b475b1292e01c918c1f8144599b5fa78688e97..67be177f92ff66074b6f0f0f82fce284
              return WORLD_SAVER_SERVICE.submit(() -> {
                  try {
                      byte[] serializedWorld = SlimeSerializer.serialize(world);
+diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
+index 529decbe9f01e874ecfb70bd1c4da016e0262d2a..feec24fcb10074932743d8dfd160458d60b5c979 100644
+--- a/src/main/java/net/minecraft/server/level/ServerLevel.java
++++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
+@@ -455,7 +455,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+                 io.papermc.paper.chunk.system.io.RegionFileIOThread.getIOBlockingPriorityForCurrentThread()
+             );
+         }
+-        return this.entityStorage.read(new ChunkPos(chunkX, chunkZ));
++        return this instanceof com.infernalsuite.aswm.level.SlimeLevelInstance ? null : this.entityStorage.read(new ChunkPos(chunkX, chunkZ));
+     }
+ 
+     private final io.papermc.paper.chunk.system.entity.EntityLookup entityLookup;

--- a/patches/server/0012-Add-v12-chunk-pdc-and-extra-nbt.-Fix-double-compress.patch
+++ b/patches/server/0012-Add-v12-chunk-pdc-and-extra-nbt.-Fix-double-compress.patch
@@ -54,10 +54,10 @@ index f1db2fe121bb3aabfad727a8133b645524b8f19a..ad30e83670ca88f09fa7625fc52c2242
          return chunk;
      }
 diff --git a/src/main/java/com/infernalsuite/aswm/level/NMSSlimeWorld.java b/src/main/java/com/infernalsuite/aswm/level/NMSSlimeWorld.java
-index 9a27369c00345bbb94aa19f77687269dc94c0b0a..e0fc007bbc324f258a8bc7975fd8d95a2644f962 100644
+index 07e542e3f75bf272f53345dc040d90358e7d7b2d..004d7bcc5b35c76855787dcf32fe460e73cab38f 100644
 --- a/src/main/java/com/infernalsuite/aswm/level/NMSSlimeWorld.java
 +++ b/src/main/java/com/infernalsuite/aswm/level/NMSSlimeWorld.java
-@@ -43,14 +43,14 @@ public class NMSSlimeWorld implements SlimeWorld {
+@@ -45,14 +45,14 @@ public class NMSSlimeWorld implements SlimeWorld {
              return null;
          }
  
@@ -114,10 +114,10 @@ index 276c48a4e9d10fd3124ce29586d3b2ef8c3a1727..9302b8bba83840eff921f0dc000344c4
  }
 \ No newline at end of file
 diff --git a/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java b/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java
-index 03f0a5c88a6b2d28a5a69649fc1295b51aaf879f..76913fab8da9509d86b8c685ad6078244257b7fc 100644
+index 092dae1f9e68f1c395cd0f8151cd696c0bcdceb0..208339f93fbd078b89d4bbb24fd8f7d3704a4736 100644
 --- a/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java
 +++ b/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java
-@@ -83,11 +83,11 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
+@@ -88,11 +88,11 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
              levelChunk = new SlimeChunkLevel(this.instance, pos, UpgradeData.EMPTY, blockLevelChunkTicks, fluidLevelChunkTicks,
                      0L, null, null, null);
  
@@ -131,7 +131,7 @@ index 03f0a5c88a6b2d28a5a69649fc1295b51aaf879f..76913fab8da9509d86b8c685ad607824
          }
          this.chunkStorage.put(new ChunkPos(x, z), chunk);
  
-@@ -100,7 +100,7 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
+@@ -105,7 +105,7 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
          final int x = providedChunk.locX;
          final int z = providedChunk.locZ;
  
@@ -140,7 +140,7 @@ index 03f0a5c88a6b2d28a5a69649fc1295b51aaf879f..76913fab8da9509d86b8c685ad607824
  
          if (FastChunkPruner.canBePruned(this.liveWorld, providedChunk)) {
              this.chunkStorage.remove(new ChunkPos(x, z));
-@@ -109,7 +109,7 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
+@@ -114,7 +114,7 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
  
          this.chunkStorage.put(new ChunkPos(x, z),
                  new SlimeChunkSkeleton(chunk.getX(), chunk.getZ(), chunk.getSections(),
@@ -149,7 +149,7 @@ index 03f0a5c88a6b2d28a5a69649fc1295b51aaf879f..76913fab8da9509d86b8c685ad607824
      }
  
      @Override
-@@ -222,13 +222,20 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
+@@ -227,13 +227,20 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
                          continue;
                      }
  

--- a/patches/server/0012-Add-v12-chunk-pdc-and-extra-nbt.-Fix-double-compress.patch
+++ b/patches/server/0012-Add-v12-chunk-pdc-and-extra-nbt.-Fix-double-compress.patch
@@ -172,18 +172,16 @@ index 092dae1f9e68f1c395cd0f8151cd696c0bcdceb0..208339f93fbd078b89d4bbb24fd8f7d3
                  }
              }
 diff --git a/src/main/java/com/infernalsuite/aswm/level/SlimeLevelInstance.java b/src/main/java/com/infernalsuite/aswm/level/SlimeLevelInstance.java
-index 65b475b1292e01c918c1f8144599b5fa78688e97..67be177f92ff66074b6f0f0f82fce284ccb229a4 100644
+index 65b475b1292e01c918c1f8144599b5fa78688e97..a525fa1781535d458c5ecb67e261520692c858ac 100644
 --- a/src/main/java/com/infernalsuite/aswm/level/SlimeLevelInstance.java
 +++ b/src/main/java/com/infernalsuite/aswm/level/SlimeLevelInstance.java
-@@ -151,9 +151,9 @@ public class SlimeLevelInstance extends ServerLevel {
+@@ -151,9 +151,7 @@ public class SlimeLevelInstance extends ServerLevel {
              Bukkit.getLogger().log(Level.INFO, "Saving world " + this.slimeInstance.getName() + "...");
              long start = System.currentTimeMillis();
  
 -            Bukkit.getLogger().log(Level.INFO, "CONVERTING NMS -> SKELETON");
-+            //Bukkit.getLogger().log(Level.INFO, "CONVERTING NMS -> SKELETON");
              SlimeWorld world = this.slimeInstance.getForSerialization();
 -            Bukkit.getLogger().log(Level.INFO, "CONVERTED TO SKELETON, PUSHING OFF-THREAD");
-+            //Bukkit.getLogger().log(Level.INFO, "CONVERTED TO SKELETON, PUSHING OFF-THREAD");
              return WORLD_SAVER_SERVICE.submit(() -> {
                  try {
                      byte[] serializedWorld = SlimeSerializer.serialize(world);


### PR DESCRIPTION
This PR attempts to add per-chunk PDC support.
To test this functionality, one can use the plugin I've coded for this https://github.com/kyngs/ASP-PDCTest/tree/pr90

@ComputerNerd100 raised concerns about how I wrap NMSChunk around the original SlimeChunk, so please review that.
This is a bigger PR, so there may be some bugs, I've done a lot of testing tho.

*Hopefully I didn't forget anything.*