### PR TITLE
Fix space leak

### DIFF
--- a/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v10/v10SlimeWorldDeSerializer.java
+++ b/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v10/v10SlimeWorldDeSerializer.java
@@ -42,133 +42,136 @@ class v10SlimeWorldDeSerializer implements VersionedByteSlimeWorldReader<SlimeWo
     public SlimeWorld deserializeWorld(byte version, SlimeLoader loader, String worldName, DataInputStream dataStream, SlimePropertyMap propertyMap, boolean readOnly)
             throws IOException, CorruptedWorldException {
 
-        // World version
-        int worldVersion = dataStream.readInt();
-        // Chunk Data
+        try (dataStream) {
+            // World version
+            int worldVersion = dataStream.readInt();
+            // Chunk Data
 
-        byte[] chunkBytes = readCompressed(dataStream);
-        Map<ChunkPos, SlimeChunk> chunks = readChunks(propertyMap, chunkBytes);
+            byte[] chunkBytes = readCompressed(dataStream);
+            Map<ChunkPos, SlimeChunk> chunks = readChunks(propertyMap, chunkBytes);
 
-        byte[] tileEntities = readCompressed(dataStream);
-        byte[] entities = readCompressed(dataStream);
-        byte[] extra = readCompressed(dataStream);
+            byte[] tileEntities = readCompressed(dataStream);
+            byte[] entities = readCompressed(dataStream);
+            byte[] extra = readCompressed(dataStream);
 
-        // Entity deserialization
-        com.flowpowered.nbt.CompoundTag entitiesCompound = readCompound(entities);
-        {
-            List<CompoundTag> serializedEntities = ((ListTag<CompoundTag>) entitiesCompound.getValue().get("entities")).getValue();
-            for (CompoundTag entityCompound : serializedEntities) {
-                ListTag<DoubleTag> listTag = (ListTag<DoubleTag>) entityCompound.getAsListTag("Pos").get();
+            // Entity deserialization
+            com.flowpowered.nbt.CompoundTag entitiesCompound = readCompound(entities);
+            {
+                List<CompoundTag> serializedEntities = ((ListTag<CompoundTag>) entitiesCompound.getValue().get("entities")).getValue();
+                for (CompoundTag entityCompound : serializedEntities) {
+                    ListTag<DoubleTag> listTag = (ListTag<DoubleTag>) entityCompound.getAsListTag("Pos").get();
 
-                int chunkX = listTag.getValue().get(0).getValue().intValue() >> 4;
-                int chunkZ = listTag.getValue().get(2).getValue().intValue() >> 4;
-                ChunkPos chunkKey = new ChunkPos(chunkX, chunkZ);
-                SlimeChunk chunk = chunks.get(chunkKey);
-                if (chunk != null) {
-                    chunk.getEntities().add(entityCompound);
+                    int chunkX = listTag.getValue().get(0).getValue().intValue() >> 4;
+                    int chunkZ = listTag.getValue().get(2).getValue().intValue() >> 4;
+                    ChunkPos chunkKey = new ChunkPos(chunkX, chunkZ);
+                    SlimeChunk chunk = chunks.get(chunkKey);
+                    if (chunk != null) {
+                        chunk.getEntities().add(entityCompound);
+                    }
                 }
             }
-        }
 
-        // Tile Entity deserialization
-        com.flowpowered.nbt.CompoundTag tileEntitiesCompound = readCompound(tileEntities);
-        for (CompoundTag tileEntityCompound : ((com.flowpowered.nbt.ListTag<com.flowpowered.nbt.CompoundTag>) tileEntitiesCompound.getValue().get("tiles")).getValue()) {
-            int chunkX = ((IntTag) tileEntityCompound.getValue().get("x")).getValue() >> 4;
-            int chunkZ = ((IntTag) tileEntityCompound.getValue().get("z")).getValue() >> 4;
-            ChunkPos pos = new ChunkPos(chunkX, chunkZ);
-            SlimeChunk chunk = chunks.get(pos);
+            // Tile Entity deserialization
+            com.flowpowered.nbt.CompoundTag tileEntitiesCompound = readCompound(tileEntities);
+            for (CompoundTag tileEntityCompound : ((com.flowpowered.nbt.ListTag<com.flowpowered.nbt.CompoundTag>) tileEntitiesCompound.getValue().get("tiles")).getValue()) {
+                int chunkX = ((IntTag) tileEntityCompound.getValue().get("x")).getValue() >> 4;
+                int chunkZ = ((IntTag) tileEntityCompound.getValue().get("z")).getValue() >> 4;
+                ChunkPos pos = new ChunkPos(chunkX, chunkZ);
+                SlimeChunk chunk = chunks.get(pos);
 
-            if (chunk == null) {
-                throw new CorruptedWorldException(worldName);
+                if (chunk == null) {
+                    throw new CorruptedWorldException(worldName);
+                }
+
+                chunk.getTileEntities().add(tileEntityCompound);
             }
 
-            chunk.getTileEntities().add(tileEntityCompound);
+            // Extra Data
+            com.flowpowered.nbt.CompoundTag extraCompound = readCompound(extra);
+
+            // World properties
+            SlimePropertyMap worldPropertyMap = propertyMap;
+            Optional<CompoundMap> propertiesMap = extraCompound
+                    .getAsCompoundTag("properties")
+                    .map(com.flowpowered.nbt.CompoundTag::getValue);
+
+            if (propertiesMap.isPresent()) {
+                worldPropertyMap = new SlimePropertyMap(propertiesMap.get());
+                worldPropertyMap.merge(propertyMap); // Override world properties
+            }
+
+            return new SkeletonSlimeWorld(worldName, loader, readOnly, chunks,
+                    extraCompound,
+                    worldPropertyMap,
+                    worldVersion
+            );
         }
-
-        // Extra Data
-        com.flowpowered.nbt.CompoundTag extraCompound = readCompound(extra);
-
-        // World properties
-        SlimePropertyMap worldPropertyMap = propertyMap;
-        Optional<CompoundMap> propertiesMap = extraCompound
-                .getAsCompoundTag("properties")
-                .map(com.flowpowered.nbt.CompoundTag::getValue);
-
-        if (propertiesMap.isPresent()) {
-            worldPropertyMap = new SlimePropertyMap(propertiesMap.get());
-            worldPropertyMap.merge(propertyMap); // Override world properties
-        }
-
-        return new SkeletonSlimeWorld(worldName, loader, readOnly, chunks,
-                extraCompound,
-                worldPropertyMap,
-                worldVersion
-        );
     }
 
     private static Map<ChunkPos, SlimeChunk> readChunks(SlimePropertyMap slimePropertyMap, byte[] bytes) throws IOException {
         Map<ChunkPos, SlimeChunk> chunkMap = new HashMap<>();
-        DataInputStream chunkData = new DataInputStream(new ByteArrayInputStream(bytes));
+        try (DataInputStream chunkData = new DataInputStream(new ByteArrayInputStream(bytes))) {
 
-        int chunks = chunkData.readInt();
-        for (int i = 0; i < chunks; i++) {
-            // coords
-            int x = chunkData.readInt();
-            int z = chunkData.readInt();
+            int chunks = chunkData.readInt();
+            for (int i = 0; i < chunks; i++) {
+                // coords
+                int x = chunkData.readInt();
+                int z = chunkData.readInt();
 
-            // Height Maps
-            byte[] heightMapData = new byte[chunkData.readInt()];
-            chunkData.read(heightMapData);
-            com.flowpowered.nbt.CompoundTag heightMaps = readCompound(heightMapData);
+                // Height Maps
+                byte[] heightMapData = new byte[chunkData.readInt()];
+                chunkData.read(heightMapData);
+                CompoundTag heightMaps = readCompound(heightMapData);
 
-            // Chunk Sections
-            {
-                // See WorldUtils
-                int sectionAmount = slimePropertyMap.getValue(SlimeProperties.CHUNK_SECTION_MAX) - slimePropertyMap.getValue(SlimeProperties.CHUNK_SECTION_MIN) + 1;
-                SlimeChunkSection[] chunkSectionArray = new SlimeChunkSection[sectionAmount];
+                // Chunk Sections
+                {
+                    // See WorldUtils
+                    int sectionAmount = slimePropertyMap.getValue(SlimeProperties.CHUNK_SECTION_MAX) - slimePropertyMap.getValue(SlimeProperties.CHUNK_SECTION_MIN) + 1;
+                    SlimeChunkSection[] chunkSectionArray = new SlimeChunkSection[sectionAmount];
 
-                int sectionCount = chunkData.readInt();
-                for (int sectionId = 0; sectionId < sectionCount; sectionId++) {
-                    // Block Light Nibble Array
-                    NibbleArray blockLightArray;
-                    if (chunkData.readBoolean()) {
-                        byte[] blockLightByteArray = new byte[ARRAY_SIZE];
-                        chunkData.read(blockLightByteArray);
-                        blockLightArray = new NibbleArray(blockLightByteArray);
-                    } else {
-                        blockLightArray = null;
+                    int sectionCount = chunkData.readInt();
+                    for (int sectionId = 0; sectionId < sectionCount; sectionId++) {
+                        // Block Light Nibble Array
+                        NibbleArray blockLightArray;
+                        if (chunkData.readBoolean()) {
+                            byte[] blockLightByteArray = new byte[ARRAY_SIZE];
+                            chunkData.read(blockLightByteArray);
+                            blockLightArray = new NibbleArray(blockLightByteArray);
+                        } else {
+                            blockLightArray = null;
+                        }
+
+                        // Sky Light Nibble Array
+                        NibbleArray skyLightArray;
+                        if (chunkData.readBoolean()) {
+                            byte[] skyLightByteArray = new byte[ARRAY_SIZE];
+                            chunkData.read(skyLightByteArray);
+                            skyLightArray = new NibbleArray(skyLightByteArray);
+                        } else {
+                            skyLightArray = null;
+                        }
+
+                        // Block data
+                        byte[] blockStateData = new byte[chunkData.readInt()];
+                        chunkData.read(blockStateData);
+                        CompoundTag blockStateTag = readCompound(blockStateData);
+
+                        // Biome Data
+                        byte[] biomeData = new byte[chunkData.readInt()];
+                        chunkData.read(biomeData);
+                        CompoundTag biomeTag = readCompound(biomeData);
+
+                        chunkSectionArray[sectionId] = new SlimeChunkSectionSkeleton(
+                                blockStateTag,
+                                biomeTag,
+                                blockLightArray,
+                                skyLightArray);
                     }
 
-                    // Sky Light Nibble Array
-                    NibbleArray skyLightArray;
-                    if (chunkData.readBoolean()) {
-                        byte[] skyLightByteArray = new byte[ARRAY_SIZE];
-                        chunkData.read(skyLightByteArray);
-                        skyLightArray = new NibbleArray(skyLightByteArray);
-                    } else {
-                        skyLightArray = null;
-                    }
-
-                    // Block data
-                    byte[] blockStateData = new byte[chunkData.readInt()];
-                    chunkData.read(blockStateData);
-                    com.flowpowered.nbt.CompoundTag blockStateTag = readCompound(blockStateData);
-
-                    // Biome Data
-                    byte[] biomeData = new byte[chunkData.readInt()];
-                    chunkData.read(biomeData);
-                    com.flowpowered.nbt.CompoundTag biomeTag = readCompound(biomeData);
-
-                    chunkSectionArray[sectionId] = new SlimeChunkSectionSkeleton(
-                            blockStateTag,
-                            biomeTag,
-                            blockLightArray,
-                            skyLightArray);
+                    chunkMap.put(new ChunkPos(x, z),
+                            new SlimeChunkSkeleton(x, z, chunkSectionArray, heightMaps, new ArrayList<>(), new ArrayList<>(), new CompoundTag("", new CompoundMap()), null)
+                    );
                 }
-
-                chunkMap.put(new ChunkPos(x, z),
-                        new SlimeChunkSkeleton(x, z, chunkSectionArray, heightMaps, new ArrayList<>(), new ArrayList<>(), new CompoundTag("", new CompoundMap()), null)
-                );
             }
         }
 

--- a/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v12/v12SlimeWorldDeSerializer.java
+++ b/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v12/v12SlimeWorldDeSerializer.java
@@ -36,110 +36,113 @@ public class v12SlimeWorldDeSerializer implements VersionedByteSlimeWorldReader<
 
     @Override
     public SlimeWorld deserializeWorld(byte version, @Nullable SlimeLoader loader, String worldName, DataInputStream dataStream, SlimePropertyMap propertyMap, boolean readOnly) throws IOException, CorruptedWorldException, NewerFormatException {
-        int worldVersion = dataStream.readInt();
+        try (dataStream) {
+            int worldVersion = dataStream.readInt();
 
-        byte[] chunkBytes = readCompressed(dataStream);
-        Map<ChunkPos, SlimeChunk> chunks = readChunks(propertyMap, chunkBytes);
+            byte[] chunkBytes = readCompressed(dataStream);
+            Map<ChunkPos, SlimeChunk> chunks = readChunks(propertyMap, chunkBytes);
 
-        byte[] extraTagBytes = readCompressed(dataStream);
-        CompoundTag extraTag = readCompound(extraTagBytes);
+            byte[] extraTagBytes = readCompressed(dataStream);
+            CompoundTag extraTag = readCompound(extraTagBytes);
 
-        SlimePropertyMap worldPropertyMap = propertyMap;
-        Optional<CompoundMap> propertiesMap = extraTag
-                .getAsCompoundTag("properties")
-                .map(CompoundTag::getValue);
+            SlimePropertyMap worldPropertyMap = propertyMap;
+            Optional<CompoundMap> propertiesMap = extraTag
+                    .getAsCompoundTag("properties")
+                    .map(CompoundTag::getValue);
 
-        if (propertiesMap.isPresent()) {
-            worldPropertyMap = new SlimePropertyMap(propertiesMap.get());
-            worldPropertyMap.merge(propertyMap);
+            if (propertiesMap.isPresent()) {
+                worldPropertyMap = new SlimePropertyMap(propertiesMap.get());
+                worldPropertyMap.merge(propertyMap);
+            }
+
+            return new SkeletonSlimeWorld(worldName, loader, readOnly, chunks, extraTag, worldPropertyMap, worldVersion);
         }
-
-        return new SkeletonSlimeWorld(worldName, loader, readOnly, chunks, extraTag, worldPropertyMap, worldVersion);
     }
 
     private static Map<ChunkPos, SlimeChunk> readChunks(SlimePropertyMap slimePropertyMap, byte[] chunkBytes) throws IOException {
         Map<ChunkPos, SlimeChunk> chunkMap = new HashMap<>();
-        DataInputStream chunkData = new DataInputStream(new ByteArrayInputStream(chunkBytes));
+        try (DataInputStream chunkData = new DataInputStream(new ByteArrayInputStream(chunkBytes))) {
 
-        int chunks = chunkData.readInt();
-        for (int i = 0; i < chunks; i++) {
-            // ChunkPos
-            int x = chunkData.readInt();
-            int z = chunkData.readInt();
+            int chunks = chunkData.readInt();
+            for (int i = 0; i < chunks; i++) {
+                // ChunkPos
+                int x = chunkData.readInt();
+                int z = chunkData.readInt();
 
-            // Sections
-            int sectionAmount = slimePropertyMap.getValue(SlimeProperties.CHUNK_SECTION_MAX) - slimePropertyMap.getValue(SlimeProperties.CHUNK_SECTION_MIN) + 1;
-            SlimeChunkSection[] chunkSections = new SlimeChunkSection[sectionAmount];
+                // Sections
+                int sectionAmount = slimePropertyMap.getValue(SlimeProperties.CHUNK_SECTION_MAX) - slimePropertyMap.getValue(SlimeProperties.CHUNK_SECTION_MIN) + 1;
+                SlimeChunkSection[] chunkSections = new SlimeChunkSection[sectionAmount];
 
-            int sectionCount = chunkData.readInt();
-            for (int sectionId = 0; sectionId < sectionCount; sectionId++) {
+                int sectionCount = chunkData.readInt();
+                for (int sectionId = 0; sectionId < sectionCount; sectionId++) {
 
-                // Block Light Nibble Array
-                NibbleArray blockLightArray;
-                if (chunkData.readBoolean()) {
-                    byte[] blockLightByteArray = new byte[ARRAY_SIZE];
-                    chunkData.read(blockLightByteArray);
-                    blockLightArray = new NibbleArray(blockLightByteArray);
-                } else {
-                    blockLightArray = null;
+                    // Block Light Nibble Array
+                    NibbleArray blockLightArray;
+                    if (chunkData.readBoolean()) {
+                        byte[] blockLightByteArray = new byte[ARRAY_SIZE];
+                        chunkData.read(blockLightByteArray);
+                        blockLightArray = new NibbleArray(blockLightByteArray);
+                    } else {
+                        blockLightArray = null;
+                    }
+
+                    // Sky Light Nibble Array
+                    NibbleArray skyLightArray;
+                    if (chunkData.readBoolean()) {
+                        byte[] skyLightByteArray = new byte[ARRAY_SIZE];
+                        chunkData.read(skyLightByteArray);
+                        skyLightArray = new NibbleArray(skyLightByteArray);
+                    } else {
+                        skyLightArray = null;
+                    }
+
+                    // Block Data
+                    byte[] blockStateData = new byte[chunkData.readInt()];
+                    chunkData.read(blockStateData);
+                    CompoundTag blockStateTag = readCompound(blockStateData);
+
+                    // Biome Data
+                    byte[] biomeData = new byte[chunkData.readInt()];
+                    chunkData.read(biomeData);
+                    CompoundTag biomeTag = readCompound(biomeData);
+
+                    chunkSections[sectionId] = new SlimeChunkSectionSkeleton(blockStateTag, biomeTag, blockLightArray, skyLightArray);
                 }
 
-                // Sky Light Nibble Array
-                NibbleArray skyLightArray;
-                if (chunkData.readBoolean()) {
-                    byte[] skyLightByteArray = new byte[ARRAY_SIZE];
-                    chunkData.read(skyLightByteArray);
-                    skyLightArray = new NibbleArray(skyLightByteArray);
-                } else {
-                    skyLightArray = null;
+                // HeightMaps
+                byte[] heightMapData = new byte[chunkData.readInt()];
+                chunkData.read(heightMapData);
+                CompoundTag heightMaps = readCompound(heightMapData);
+
+                // Tile Entities
+
+                byte[] tileEntities = read(chunkData);
+
+                CompoundTag tileEntitiesCompound = readCompound(tileEntities);
+                @SuppressWarnings("unchecked")
+                List<CompoundTag> serializedTileEntities = ((ListTag<CompoundTag>) tileEntitiesCompound.getValue().get("tileEntities")).getValue();
+
+                // Entities
+
+                byte[] entities = read(chunkData);
+
+                CompoundTag entitiesCompound = readCompound(entities);
+                @SuppressWarnings("unchecked")
+                List<CompoundTag> serializedEntities = ((ListTag<CompoundTag>) entitiesCompound.getValue().get("entities")).getValue();
+
+
+                // Extra Tag
+                byte[] rawExtra = read(chunkData);
+                CompoundTag extra = readCompound(rawExtra);
+                // If the extra tag is empty, the serializer will save it as null.
+                // So if we deserialize a null extra tag, we will assume it was empty.
+                if (extra == null) {
+                    extra = new CompoundTag("", new CompoundMap());
                 }
 
-                // Block Data
-                byte[] blockStateData = new byte[chunkData.readInt()];
-                chunkData.read(blockStateData);
-                CompoundTag blockStateTag = readCompound(blockStateData);
-
-                // Biome Data
-                byte[] biomeData = new byte[chunkData.readInt()];
-                chunkData.read(biomeData);
-                CompoundTag biomeTag = readCompound(biomeData);
-
-                chunkSections[sectionId] = new SlimeChunkSectionSkeleton(blockStateTag, biomeTag, blockLightArray, skyLightArray);
+                chunkMap.put(new ChunkPos(x, z),
+                        new SlimeChunkSkeleton(x, z, chunkSections, heightMaps, serializedTileEntities, serializedEntities, extra, null));
             }
-
-            // HeightMaps
-            byte[] heightMapData = new byte[chunkData.readInt()];
-            chunkData.read(heightMapData);
-            CompoundTag heightMaps = readCompound(heightMapData);
-
-            // Tile Entities
-
-            byte[] tileEntities = read(chunkData);
-
-            CompoundTag tileEntitiesCompound = readCompound(tileEntities);
-            @SuppressWarnings("unchecked")
-            List<CompoundTag> serializedTileEntities = ((ListTag<CompoundTag>) tileEntitiesCompound.getValue().get("tileEntities")).getValue();
-
-            // Entities
-
-            byte[] entities = read(chunkData);
-
-            CompoundTag entitiesCompound = readCompound(entities);
-            @SuppressWarnings("unchecked")
-            List<CompoundTag> serializedEntities = ((ListTag<CompoundTag>) entitiesCompound.getValue().get("entities")).getValue();
-
-
-            // Extra Tag
-            byte[] rawExtra = read(chunkData);
-            CompoundTag extra = readCompound(rawExtra);
-            // If the extra tag is empty, the serializer will save it as null.
-            // So if we deserialize a null extra tag, we will assume it was empty.
-            if (extra == null) {
-                extra = new CompoundTag("", new CompoundMap());
-            }
-
-            chunkMap.put(new ChunkPos(x, z),
-                    new SlimeChunkSkeleton(x, z, chunkSections, heightMaps, serializedTileEntities, serializedEntities, extra, null));
         }
         return chunkMap;
     }

--- a/plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/file/FileLoader.java
+++ b/plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/file/FileLoader.java
@@ -54,21 +54,22 @@ public class FileLoader implements SlimeLoader {
 //
 //        });
 
-        RandomAccessFile file = new RandomAccessFile(new File(worldDir, worldName + ".slime"), "rw");
-
-
-        if (file != null && file.length() > Integer.MAX_VALUE) {
-            throw new IndexOutOfBoundsException("World is too big!");
+        File worldFile = new File(worldDir, worldName + ".slime");
+        if (!worldFile.exists()) {
+            throw new UnknownWorldException(worldName);
         }
+        try (RandomAccessFile file = new RandomAccessFile(worldFile, "rw")) {
+            if (file.length() > Integer.MAX_VALUE) {
+                throw new IndexOutOfBoundsException("World is too big!");
+            }
 
-        byte[] serializedWorld = new byte[0];
-        if (file != null) {
+            byte[] serializedWorld = new byte[0];
             serializedWorld = new byte[(int) file.length()];
             file.seek(0); // Make sure we're at the start of the file
             file.readFully(serializedWorld);
-        }
 
-        return serializedWorld;
+            return serializedWorld;
+        }
     }
 
     @Override

--- a/plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/file/FileLoader.java
+++ b/plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/file/FileLoader.java
@@ -63,8 +63,7 @@ public class FileLoader implements SlimeLoader {
                 throw new IndexOutOfBoundsException("World is too big!");
             }
 
-            byte[] serializedWorld = new byte[0];
-            serializedWorld = new byte[(int) file.length()];
+            byte[] serializedWorld = new byte[(int) file.length()];
             file.seek(0); // Make sure we're at the start of the file
             file.readFully(serializedWorld);
 


### PR DESCRIPTION
While trying to load a world from filesystem created object isn't closed. Serialization is also a similar case. Passed data stream isn't closed while this is final stage of serialization so there's no need to keep it open.