### PR TITLE
replace ChunkPos with long

### DIFF
--- a/core/src/main/java/com/infernalsuite/aswm/ChunkPos.java
+++ b/core/src/main/java/com/infernalsuite/aswm/ChunkPos.java
@@ -1,5 +1,0 @@
-package com.infernalsuite.aswm;
-
-public record ChunkPos(int x, int z) {
-
-}

--- a/core/src/main/java/com/infernalsuite/aswm/Util.java
+++ b/core/src/main/java/com/infernalsuite/aswm/Util.java
@@ -1,0 +1,12 @@
+package com.infernalsuite.aswm;
+
+public final class Util {
+
+  private Util() {
+    throw new AssertionError();
+  }
+
+  public static long chunkPosition(final int x, final int z) {
+    return ((((long) x) << 32) | (z & 0xFFFFFFFFL));
+  }
+}

--- a/core/src/main/java/com/infernalsuite/aswm/serialization/anvil/AnvilWorldReader.java
+++ b/core/src/main/java/com/infernalsuite/aswm/serialization/anvil/AnvilWorldReader.java
@@ -6,7 +6,7 @@ import com.flowpowered.nbt.IntTag;
 import com.flowpowered.nbt.ListTag;
 import com.flowpowered.nbt.TagType;
 import com.flowpowered.nbt.stream.NBTInputStream;
-import com.infernalsuite.aswm.ChunkPos;
+import com.infernalsuite.aswm.Util;
 import com.infernalsuite.aswm.api.exceptions.InvalidWorldException;
 import com.infernalsuite.aswm.api.utils.NibbleArray;
 import com.infernalsuite.aswm.api.world.SlimeChunk;
@@ -19,7 +19,8 @@ import com.infernalsuite.aswm.skeleton.SkeletonSlimeWorld;
 import com.infernalsuite.aswm.skeleton.SlimeChunkSectionSkeleton;
 import com.infernalsuite.aswm.skeleton.SlimeChunkSkeleton;
 
-import javax.swing.filechooser.FileNameExtensionFilter;
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import java.io.*;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -82,13 +83,13 @@ public class AnvilWorldReader implements SlimeWorldReader<AnvilImportData> {
                 throw new InvalidWorldException(environmentDir);
             }
 
-            Map<ChunkPos, SlimeChunk> chunks = new HashMap<>();
+            Long2ObjectMap<SlimeChunk> chunks = new Long2ObjectOpenHashMap<>();
 
             for (File file : Objects.requireNonNull(regionDir.listFiles((dir, name) -> name.endsWith(".mca")))) {
                 System.out.println("Loading region file: " + file.getName() + "...");
                 if (file.exists()) {
                     chunks.putAll(
-                            loadChunks(file, worldVersion).stream().collect(Collectors.toMap((chunk) -> new ChunkPos(chunk.getX(), chunk.getZ()), (chunk) -> chunk))
+                            loadChunks(file, worldVersion).stream().collect(Collectors.toMap((chunk) -> Util.chunkPosition(chunk.getX(), chunk.getZ()), (chunk) -> chunk))
                     );
                 }
             }
@@ -177,7 +178,7 @@ public class AnvilWorldReader implements SlimeWorldReader<AnvilImportData> {
         throw new InvalidWorldException(file.getParentFile());
     }
 
-    private static void loadEntities(File file, int version, Map<ChunkPos, SlimeChunk> chunkMap) throws IOException {
+    private static void loadEntities(File file, int version, Long2ObjectMap<SlimeChunk> chunkMap) throws IOException {
         byte[] regionByteArray = Files.readAllBytes(file.toPath());
         DataInputStream inputStream = new DataInputStream(new ByteArrayInputStream(regionByteArray));
 
@@ -260,7 +261,7 @@ public class AnvilWorldReader implements SlimeWorldReader<AnvilImportData> {
         }).filter(Objects::nonNull).collect(Collectors.toList());
     }
 
-    private static void readEntityChunk(CompoundTag compound, int worldVersion, Map<ChunkPos, SlimeChunk> slimeChunkMap) {
+    private static void readEntityChunk(CompoundTag compound, int worldVersion, Long2ObjectMap<SlimeChunk> slimeChunkMap) {
         int[] position = compound.getAsIntArrayTag("Position").orElseThrow().getValue();
         int chunkX = position[0];
         int chunkZ = position[1];
@@ -271,7 +272,7 @@ public class AnvilWorldReader implements SlimeWorldReader<AnvilImportData> {
             return;
         }
 
-        SlimeChunk chunk = slimeChunkMap.get(new ChunkPos(chunkX, chunkZ));
+        SlimeChunk chunk = slimeChunkMap.get(Util.chunkPosition(chunkX, chunkZ));
         if (chunk == null) {
             System.out.println("Lost entity chunk data at: " + chunkX + " " + chunkZ);
         } else {

--- a/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v11/v11SlimeWorldDeSerializer.java
+++ b/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v11/v11SlimeWorldDeSerializer.java
@@ -5,7 +5,7 @@ import com.flowpowered.nbt.CompoundTag;
 import com.flowpowered.nbt.ListTag;
 import com.flowpowered.nbt.stream.NBTInputStream;
 import com.github.luben.zstd.Zstd;
-import com.infernalsuite.aswm.ChunkPos;
+import com.infernalsuite.aswm.Util;
 import com.infernalsuite.aswm.api.exceptions.CorruptedWorldException;
 import com.infernalsuite.aswm.api.exceptions.NewerFormatException;
 import com.infernalsuite.aswm.api.loaders.SlimeLoader;
@@ -19,6 +19,8 @@ import com.infernalsuite.aswm.serialization.slime.reader.VersionedByteSlimeWorld
 import com.infernalsuite.aswm.skeleton.SkeletonSlimeWorld;
 import com.infernalsuite.aswm.skeleton.SlimeChunkSectionSkeleton;
 import com.infernalsuite.aswm.skeleton.SlimeChunkSkeleton;
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.ByteArrayInputStream;
@@ -39,7 +41,7 @@ public class v11SlimeWorldDeSerializer implements VersionedByteSlimeWorldReader<
         int worldVersion = dataStream.readInt();
 
         byte[] chunkBytes = readCompressed(dataStream);
-        Map<ChunkPos, SlimeChunk> chunks = readChunks(propertyMap, chunkBytes);
+        Long2ObjectMap<SlimeChunk> chunks = readChunks(propertyMap, chunkBytes);
 
         byte[] extraTagBytes = readCompressed(dataStream);
         CompoundTag extraTag = readCompound(extraTagBytes);
@@ -57,8 +59,8 @@ public class v11SlimeWorldDeSerializer implements VersionedByteSlimeWorldReader<
         return new SkeletonSlimeWorld(worldName, loader, readOnly, chunks, extraTag, worldPropertyMap, worldVersion);
     }
 
-    private static Map<ChunkPos, SlimeChunk> readChunks(SlimePropertyMap slimePropertyMap, byte[] chunkBytes) throws IOException {
-        Map<ChunkPos, SlimeChunk> chunkMap = new HashMap<>();
+    private static Long2ObjectMap<SlimeChunk> readChunks(SlimePropertyMap slimePropertyMap, byte[] chunkBytes) throws IOException {
+        Long2ObjectMap<SlimeChunk> chunkMap = new Long2ObjectOpenHashMap<>();
         DataInputStream chunkData = new DataInputStream(new ByteArrayInputStream(chunkBytes));
 
         int chunks = chunkData.readInt();
@@ -138,7 +140,7 @@ public class v11SlimeWorldDeSerializer implements VersionedByteSlimeWorldReader<
             @SuppressWarnings("unchecked")
             List<CompoundTag> serializedEntities = ((ListTag<CompoundTag>) entitiesCompound.getValue().get("entities")).getValue();
 
-            chunkMap.put(new ChunkPos(x, z),
+            chunkMap.put(Util.chunkPosition(x, z),
                     new SlimeChunkSkeleton(x, z, chunkSections, heightMaps, serializedTileEntities, serializedEntities, new CompoundTag("", new CompoundMap()), null));
         }
         return chunkMap;

--- a/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v12/v12SlimeWorldDeSerializer.java
+++ b/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v12/v12SlimeWorldDeSerializer.java
@@ -5,7 +5,7 @@ import com.flowpowered.nbt.CompoundTag;
 import com.flowpowered.nbt.ListTag;
 import com.flowpowered.nbt.stream.NBTInputStream;
 import com.github.luben.zstd.Zstd;
-import com.infernalsuite.aswm.ChunkPos;
+import com.infernalsuite.aswm.Util;
 import com.infernalsuite.aswm.api.exceptions.CorruptedWorldException;
 import com.infernalsuite.aswm.api.exceptions.NewerFormatException;
 import com.infernalsuite.aswm.api.loaders.SlimeLoader;
@@ -19,6 +19,8 @@ import com.infernalsuite.aswm.serialization.slime.reader.VersionedByteSlimeWorld
 import com.infernalsuite.aswm.skeleton.SkeletonSlimeWorld;
 import com.infernalsuite.aswm.skeleton.SlimeChunkSectionSkeleton;
 import com.infernalsuite.aswm.skeleton.SlimeChunkSkeleton;
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.ByteArrayInputStream;
@@ -39,7 +41,7 @@ public class v12SlimeWorldDeSerializer implements VersionedByteSlimeWorldReader<
         int worldVersion = dataStream.readInt();
 
         byte[] chunkBytes = readCompressed(dataStream);
-        Map<ChunkPos, SlimeChunk> chunks = readChunks(propertyMap, chunkBytes);
+        Long2ObjectMap<SlimeChunk> chunks = readChunks(propertyMap, chunkBytes);
 
         byte[] extraTagBytes = readCompressed(dataStream);
         CompoundTag extraTag = readCompound(extraTagBytes);
@@ -57,8 +59,8 @@ public class v12SlimeWorldDeSerializer implements VersionedByteSlimeWorldReader<
         return new SkeletonSlimeWorld(worldName, loader, readOnly, chunks, extraTag, worldPropertyMap, worldVersion);
     }
 
-    private static Map<ChunkPos, SlimeChunk> readChunks(SlimePropertyMap slimePropertyMap, byte[] chunkBytes) throws IOException {
-        Map<ChunkPos, SlimeChunk> chunkMap = new HashMap<>();
+    private static Long2ObjectMap<SlimeChunk> readChunks(SlimePropertyMap slimePropertyMap, byte[] chunkBytes) throws IOException {
+        Long2ObjectMap<SlimeChunk> chunkMap = new Long2ObjectOpenHashMap<>();
         DataInputStream chunkData = new DataInputStream(new ByteArrayInputStream(chunkBytes));
 
         int chunks = chunkData.readInt();
@@ -138,7 +140,7 @@ public class v12SlimeWorldDeSerializer implements VersionedByteSlimeWorldReader<
                 extra = new CompoundTag("", new CompoundMap());
             }
 
-            chunkMap.put(new ChunkPos(x, z),
+            chunkMap.put(Util.chunkPosition(x, z),
                     new SlimeChunkSkeleton(x, z, chunkSections, heightMaps, serializedTileEntities, serializedEntities, extra, null));
         }
         return chunkMap;

--- a/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v1_9/v1_9SlimeWorld.java
+++ b/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v1_9/v1_9SlimeWorld.java
@@ -1,18 +1,16 @@
 package com.infernalsuite.aswm.serialization.slime.reader.impl.v1_9;
 
 import com.flowpowered.nbt.CompoundTag;
-import com.infernalsuite.aswm.ChunkPos;
 import com.infernalsuite.aswm.api.loaders.SlimeLoader;
 import com.infernalsuite.aswm.api.world.properties.SlimePropertyMap;
-
-import java.util.Map;
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 
 public class v1_9SlimeWorld {
 
     public byte version;
     public final String worldName;
     public final SlimeLoader loader;
-    public final Map<ChunkPos, v1_9SlimeChunk> chunks;
+    public final Long2ObjectMap<v1_9SlimeChunk> chunks;
     public final CompoundTag extraCompound;
     public final SlimePropertyMap propertyMap;
     public final boolean readOnly;
@@ -20,7 +18,7 @@ public class v1_9SlimeWorld {
     public v1_9SlimeWorld(byte version,
                    String worldName,
                    SlimeLoader loader,
-                   Map<ChunkPos, v1_9SlimeChunk> chunks,
+                   Long2ObjectMap<v1_9SlimeChunk> chunks,
                    CompoundTag extraCompound,
                    SlimePropertyMap propertyMap,
                    boolean readOnly) {

--- a/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v1_9/v1_v9SlimeConverter.java
+++ b/core/src/main/java/com/infernalsuite/aswm/serialization/slime/reader/impl/v1_9/v1_v9SlimeConverter.java
@@ -1,7 +1,6 @@
 package com.infernalsuite.aswm.serialization.slime.reader.impl.v1_9;
 
 import com.flowpowered.nbt.*;
-import com.infernalsuite.aswm.ChunkPos;
 import com.infernalsuite.aswm.serialization.SlimeWorldReader;
 import com.infernalsuite.aswm.serialization.slime.reader.impl.v1_9.upgrade.*;
 import com.infernalsuite.aswm.skeleton.SkeletonSlimeWorld;
@@ -11,6 +10,8 @@ import com.infernalsuite.aswm.api.world.SlimeChunk;
 import com.infernalsuite.aswm.api.world.SlimeChunkSection;
 import com.infernalsuite.aswm.api.world.SlimeWorld;
 
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -34,8 +35,8 @@ class v1_v9SlimeConverter implements SlimeWorldReader<v1_9SlimeWorld> {
     public SlimeWorld readFromData(v1_9SlimeWorld data) {
         int dataVersion = upgradeWorld(data);
 
-        Map<ChunkPos, SlimeChunk> chunks = new HashMap<>();
-        for (Map.Entry<ChunkPos, v1_9SlimeChunk> entry : data.chunks.entrySet()) {
+        Long2ObjectMap<SlimeChunk> chunks = new Long2ObjectOpenHashMap<>();
+        for (Long2ObjectMap.Entry<v1_9SlimeChunk> entry : data.chunks.long2ObjectEntrySet()) {
             v1_9SlimeChunk slimeChunk = entry.getValue();
 
             SlimeChunkSection[] sections = new SlimeChunkSection[slimeChunk.sections.length];
@@ -84,7 +85,7 @@ class v1_v9SlimeConverter implements SlimeWorldReader<v1_9SlimeWorld> {
             //    slimeChunk.minY,
             //    slimeChunk.maxY,
 
-            chunks.put(entry.getKey(), new SlimeChunkSkeleton(
+            chunks.put(entry.getLongKey(), new SlimeChunkSkeleton(
                     slimeChunk.x,
                     slimeChunk.z,
                     sections,

--- a/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonCloning.java
+++ b/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonCloning.java
@@ -1,13 +1,15 @@
 package com.infernalsuite.aswm.skeleton;
 
 import com.flowpowered.nbt.CompoundTag;
-import com.infernalsuite.aswm.ChunkPos;
+import com.infernalsuite.aswm.Util;
 import com.infernalsuite.aswm.api.loaders.SlimeLoader;
 import com.infernalsuite.aswm.api.utils.NibbleArray;
 import com.infernalsuite.aswm.api.world.SlimeChunk;
 import com.infernalsuite.aswm.api.world.SlimeChunkSection;
 import com.infernalsuite.aswm.api.world.SlimeWorld;
 
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import java.util.*;
 
 public class SkeletonCloning {
@@ -23,9 +25,9 @@ public class SkeletonCloning {
     }
 
     public static SkeletonSlimeWorld weakCopy(SlimeWorld world) {
-        Map<ChunkPos, SlimeChunk> cloned = new HashMap<>();
+        Long2ObjectMap<SlimeChunk> cloned = new Long2ObjectOpenHashMap<>();
         for (SlimeChunk chunk : world.getChunkStorage()) {
-            ChunkPos pos = new ChunkPos(chunk.getX(), chunk.getZ());
+            long pos = Util.chunkPosition(chunk.getX(), chunk.getZ());
 
             cloned.put(pos, chunk);
         }
@@ -40,10 +42,10 @@ public class SkeletonCloning {
     }
 
 
-    private static Map<ChunkPos, SlimeChunk> cloneChunkStorage(Collection<SlimeChunk> slimeChunkMap) {
-        Map<ChunkPos, SlimeChunk> cloned = new HashMap<>();
+    private static Long2ObjectMap<SlimeChunk> cloneChunkStorage(Collection<SlimeChunk> slimeChunkMap) {
+        Long2ObjectMap<SlimeChunk> cloned = new Long2ObjectOpenHashMap<>();
         for (SlimeChunk chunk : slimeChunkMap) {
-            ChunkPos pos = new ChunkPos(chunk.getX(), chunk.getZ());
+            long pos = Util.chunkPosition(chunk.getX(), chunk.getZ());
 
             SlimeChunkSection[] copied = new SlimeChunkSection[chunk.getSections().length];
             for (int i = 0; i < copied.length; i++) {

--- a/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonSlimeWorld.java
+++ b/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonSlimeWorld.java
@@ -1,7 +1,7 @@
 package com.infernalsuite.aswm.skeleton;
 
 import com.flowpowered.nbt.CompoundTag;
-import com.infernalsuite.aswm.ChunkPos;
+import com.infernalsuite.aswm.Util;
 import com.infernalsuite.aswm.api.exceptions.WorldAlreadyExistsException;
 import com.infernalsuite.aswm.api.loaders.SlimeLoader;
 import com.infernalsuite.aswm.api.world.SlimeChunk;
@@ -9,6 +9,7 @@ import com.infernalsuite.aswm.api.world.SlimeWorld;
 import com.infernalsuite.aswm.api.world.properties.SlimePropertyMap;
 import com.infernalsuite.aswm.pdc.FlowPersistentDataContainer;
 import com.infernalsuite.aswm.serialization.slime.SlimeSerializer;
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -23,7 +24,7 @@ public final class SkeletonSlimeWorld implements SlimeWorld {
     private final String name;
     private final @Nullable SlimeLoader loader;
     private final boolean readOnly;
-    private final Map<ChunkPos, SlimeChunk> chunkStorage;
+    private final Long2ObjectMap<SlimeChunk> chunkStorage;
     private final CompoundTag extraSerialized;
     private final SlimePropertyMap slimePropertyMap;
     private final int dataVersion;
@@ -33,7 +34,7 @@ public final class SkeletonSlimeWorld implements SlimeWorld {
             String name,
             @Nullable SlimeLoader loader,
             boolean readOnly,
-            Map<ChunkPos, SlimeChunk> chunkStorage,
+            Long2ObjectMap<SlimeChunk> chunkStorage,
             CompoundTag extraSerialized,
             SlimePropertyMap slimePropertyMap,
             int dataVersion
@@ -60,7 +61,7 @@ public final class SkeletonSlimeWorld implements SlimeWorld {
 
     @Override
     public SlimeChunk getChunk(int x, int z) {
-        return this.chunkStorage.get(new ChunkPos(x, z));
+        return this.chunkStorage.get(Util.chunkPosition(x, z));
     }
 
     @Override
@@ -142,7 +143,7 @@ public final class SkeletonSlimeWorld implements SlimeWorld {
         return readOnly;
     }
 
-    public Map<ChunkPos, SlimeChunk> chunkStorage() {
+    public Long2ObjectMap<SlimeChunk> chunkStorage() {
         return chunkStorage;
     }
 

--- a/patches/server/0013-replace-ChunkPos-with-long.patch
+++ b/patches/server/0013-replace-ChunkPos-with-long.patch
@@ -1,0 +1,140 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Aaron <bauhd@gmx.net>
+Date: Sun, 16 Jun 2024 03:06:08 +0200
+Subject: [PATCH] replace ChunkPos with long
+
+
+diff --git a/src/main/java/com/infernalsuite/aswm/SimpleDataFixerConverter.java b/src/main/java/com/infernalsuite/aswm/SimpleDataFixerConverter.java
+index ba203e3dc9f6b0be5a92c30808daa0c284616f09..eb441905b43c0f2f7edc104a34f78a18d8f3bedf 100644
+--- a/src/main/java/com/infernalsuite/aswm/SimpleDataFixerConverter.java
++++ b/src/main/java/com/infernalsuite/aswm/SimpleDataFixerConverter.java
+@@ -12,6 +12,8 @@ import com.infernalsuite.aswm.skeleton.SlimeChunkSkeleton;
+ import com.infernalsuite.aswm.api.world.SlimeChunk;
+ import com.infernalsuite.aswm.api.world.SlimeChunkSection;
+ import com.infernalsuite.aswm.api.world.SlimeWorld;
++import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
++import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+ import net.minecraft.SharedConstants;
+ 
+ import java.util.ArrayList;
+@@ -34,7 +36,7 @@ class SimpleDataFixerConverter implements SlimeWorldReader<SlimeWorld> {
+         long encodedNewVersion = DataConverter.encodeVersions(newVersion, Integer.MAX_VALUE);
+         long encodedCurrentVersion = DataConverter.encodeVersions(currentVersion, Integer.MAX_VALUE);
+ 
+-        Map<com.infernalsuite.aswm.ChunkPos, SlimeChunk> chunks = new HashMap<>();
++        Long2ObjectMap<SlimeChunk> chunks = new Long2ObjectOpenHashMap<>();
+         for (SlimeChunk chunk : data.getChunkStorage()) {
+             List<CompoundTag> entities = new ArrayList<>();
+             List<CompoundTag> blockEntities = new ArrayList<>();
+@@ -49,7 +51,7 @@ class SimpleDataFixerConverter implements SlimeWorldReader<SlimeWorld> {
+                 );
+             }
+ 
+-            ChunkPos chunkPos = new ChunkPos(chunk.getX(), chunk.getZ());
++            long chunkPos = Util.chunkPosition(chunk.getX(), chunk.getZ());
+ 
+             SlimeChunkSection[] sections = new SlimeChunkSection[chunk.getSections().length];
+             for (int i = 0; i < sections.length; i++) {
+diff --git a/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java b/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java
+index b54b231e22967eb0b34e6ba9b7ec9cdf64bad87e..1f70cc97e79d532ea0e9428e3b5d462482501135 100644
+--- a/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java
++++ b/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java
+@@ -2,8 +2,8 @@ package com.infernalsuite.aswm.level;
+ 
+ import com.flowpowered.nbt.CompoundTag;
+ import com.flowpowered.nbt.Tag;
+-import com.infernalsuite.aswm.ChunkPos;
+ import com.infernalsuite.aswm.Converter;
++import com.infernalsuite.aswm.Util;
+ import com.infernalsuite.aswm.api.exceptions.WorldAlreadyExistsException;
+ import com.infernalsuite.aswm.api.loaders.SlimeLoader;
+ import com.infernalsuite.aswm.pdc.FlowPersistentDataContainer;
+@@ -15,6 +15,8 @@ import com.infernalsuite.aswm.api.world.SlimeChunk;
+ import com.infernalsuite.aswm.api.world.SlimeWorld;
+ import com.infernalsuite.aswm.api.world.SlimeWorldInstance;
+ import com.infernalsuite.aswm.api.world.properties.SlimePropertyMap;
++import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
++import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+ import net.minecraft.world.level.block.Block;
+ import net.minecraft.world.level.chunk.LevelChunk;
+ import net.minecraft.world.level.chunk.UpgradeData;
+@@ -46,7 +48,7 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
+     private final SlimePropertyMap propertyMap;
+     private final SlimeLoader loader;
+ 
+-    private final Map<ChunkPos, SlimeChunk> chunkStorage = new HashMap<>();
++    private final Long2ObjectMap<SlimeChunk> chunkStorage = new Long2ObjectOpenHashMap<>();
+     private boolean readOnly;
+     // private final Map<ChunkPos, List<CompoundTag>> entityStorage = new HashMap<>();
+ 
+@@ -58,7 +60,7 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
+         this.readOnly = bootstrap.initial().isReadOnly();
+ 
+         for (SlimeChunk initial : bootstrap.initial().getChunkStorage()) {
+-            ChunkPos pos = new ChunkPos(initial.getX(), initial.getZ());
++            long pos = Util.chunkPosition(initial.getX(), initial.getZ());
+             List<CompoundTag> tags = new ArrayList<>(initial.getEntities());
+ 
+             //  this.entityStorage.put(pos, tags);
+@@ -95,7 +97,7 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
+             levelChunk = SlimeChunkConverter.deserializeSlimeChunk(this.instance, chunk);
+             chunk = new SafeNmsChunkWrapper(new NMSSlimeChunk(levelChunk, chunk), chunk);
+         }
+-        this.chunkStorage.put(new ChunkPos(x, z), chunk);
++        this.chunkStorage.put(Util.chunkPosition(x, z), chunk);
+ 
+         return levelChunk;
+     }
+@@ -109,18 +111,18 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
+         SlimeChunk chunk = new NMSSlimeChunk(providedChunk, getChunk(x, z));
+ 
+         if (FastChunkPruner.canBePruned(this.liveWorld, providedChunk)) {
+-            this.chunkStorage.remove(new ChunkPos(x, z));
++            this.chunkStorage.remove(Util.chunkPosition(x, z));
+             return;
+         }
+ 
+-        this.chunkStorage.put(new ChunkPos(x, z),
++        this.chunkStorage.put(Util.chunkPosition(x, z),
+                 new SlimeChunkSkeleton(chunk.getX(), chunk.getZ(), chunk.getSections(),
+                         chunk.getHeightMaps(), chunk.getTileEntities(), chunk.getEntities(), chunk.getExtraData(), null));
+     }
+ 
+     @Override
+     public SlimeChunk getChunk(int x, int z) {
+-        return this.chunkStorage.get(new ChunkPos(x, z));
++        return this.chunkStorage.get(Util.chunkPosition(x, z));
+     }
+ 
+     @Override
+@@ -207,8 +209,8 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
+     public SlimeWorld getForSerialization() {
+         SlimeWorld world = SkeletonCloning.weakCopy(this);
+ 
+-        Map<ChunkPos, SlimeChunk> cloned = new HashMap<>();
+-        for (Map.Entry<ChunkPos, SlimeChunk> entry : this.chunkStorage.entrySet()) {
++        Long2ObjectMap<SlimeChunk> cloned = new Long2ObjectOpenHashMap<>();
++        for (Long2ObjectMap.Entry<SlimeChunk> entry : this.chunkStorage.long2ObjectEntrySet()) {
+             SlimeChunk clonedChunk = entry.getValue();
+             // NMS "live" chunks need to be converted
+             {
+@@ -247,7 +249,7 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
+                 }
+             }
+ 
+-            cloned.put(entry.getKey(), clonedChunk);
++            cloned.put(entry.getLongKey(), clonedChunk);
+         }
+ 
+         // Serialize Bukkit Values (PDC)
+@@ -281,8 +283,8 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
+     }
+ 
+     public void ensureChunkMarkedAsLoaded(SlimeChunkLevel chunk) {
+-        if (chunkStorage.get(new ChunkPos(chunk.locX, chunk.locZ)) instanceof SlimeChunkSkeleton skeleton) {
+-            chunkStorage.put(new ChunkPos(chunk.locX, chunk.locZ), new NMSSlimeChunk(chunk, skeleton));
++        if (chunkStorage.get(Util.chunkPosition(chunk.locX, chunk.locZ)) instanceof SlimeChunkSkeleton skeleton) {
++            chunkStorage.put(Util.chunkPosition(chunk.locX, chunk.locZ), new NMSSlimeChunk(chunk, skeleton));
+         }
+     }
+ }

--- a/patches/server/0014-replace-ChunkPos-with-long.patch
+++ b/patches/server/0014-replace-ChunkPos-with-long.patch
@@ -36,7 +36,7 @@ index ba203e3dc9f6b0be5a92c30808daa0c284616f09..eb441905b43c0f2f7edc104a34f78a18
              SlimeChunkSection[] sections = new SlimeChunkSection[chunk.getSections().length];
              for (int i = 0; i < sections.length; i++) {
 diff --git a/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java b/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java
-index b54b231e22967eb0b34e6ba9b7ec9cdf64bad87e..1f70cc97e79d532ea0e9428e3b5d462482501135 100644
+index 114da62698c2897b16042327a4171f785bc58cec..770679851baba2ddb9f8f427f4cd80ea8b32122b 100644
 --- a/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java
 +++ b/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java
 @@ -2,8 +2,8 @@ package com.infernalsuite.aswm.level;
@@ -107,7 +107,7 @@ index b54b231e22967eb0b34e6ba9b7ec9cdf64bad87e..1f70cc97e79d532ea0e9428e3b5d4624
      }
  
      @Override
-@@ -207,8 +209,8 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
+@@ -202,8 +204,8 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
      public SlimeWorld getForSerialization() {
          SlimeWorld world = SkeletonCloning.weakCopy(this);
  
@@ -118,7 +118,7 @@ index b54b231e22967eb0b34e6ba9b7ec9cdf64bad87e..1f70cc97e79d532ea0e9428e3b5d4624
              SlimeChunk clonedChunk = entry.getValue();
              // NMS "live" chunks need to be converted
              {
-@@ -247,7 +249,7 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
+@@ -242,7 +244,7 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
                  }
              }
  
@@ -127,7 +127,7 @@ index b54b231e22967eb0b34e6ba9b7ec9cdf64bad87e..1f70cc97e79d532ea0e9428e3b5d4624
          }
  
          // Serialize Bukkit Values (PDC)
-@@ -281,8 +283,8 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
+@@ -276,8 +278,8 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
      }
  
      public void ensureChunkMarkedAsLoaded(SlimeChunkLevel chunk) {

--- a/patches/server/0014-replace-ChunkPos-with-long.patch
+++ b/patches/server/0014-replace-ChunkPos-with-long.patch
@@ -4,6 +4,19 @@ Date: Sun, 16 Jun 2024 03:06:08 +0200
 Subject: [PATCH] replace ChunkPos with long
 
 
+diff --git a/src/main/java/com/infernalsuite/aswm/AdvancedSlimePaper.java b/src/main/java/com/infernalsuite/aswm/AdvancedSlimePaper.java
+index 50350820d228e3656c569176aafd2cc534c17c15..72ae13b9f5f7db25a1a76b2f3855d37c44d8fcbd 100644
+--- a/src/main/java/com/infernalsuite/aswm/AdvancedSlimePaper.java
++++ b/src/main/java/com/infernalsuite/aswm/AdvancedSlimePaper.java
+@@ -168,7 +168,7 @@ public class AdvancedSlimePaper implements AdvancedSlimePaperAPI {
+         Objects.requireNonNull(worldName, "World name cannot be null");
+         Objects.requireNonNull(propertyMap, "Properties cannot be null");
+ 
+-        return new SkeletonSlimeWorld(worldName, loader, readOnly, Map.of(), new CompoundTag("", new CompoundMap()), propertyMap, BRIDGE_INSTANCE.getCurrentVersion());
++        return new SkeletonSlimeWorld(worldName, loader, readOnly, new it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap<>(0), new CompoundTag("", new CompoundMap()), propertyMap, BRIDGE_INSTANCE.getCurrentVersion());
+     }
+ 
+     @Override
 diff --git a/src/main/java/com/infernalsuite/aswm/SimpleDataFixerConverter.java b/src/main/java/com/infernalsuite/aswm/SimpleDataFixerConverter.java
 index ba203e3dc9f6b0be5a92c30808daa0c284616f09..eb441905b43c0f2f7edc104a34f78a18d8f3bedf 100644
 --- a/src/main/java/com/infernalsuite/aswm/SimpleDataFixerConverter.java

--- a/patches/server/0014-replace-ChunkPos-with-long.patch
+++ b/patches/server/0014-replace-ChunkPos-with-long.patch
@@ -5,15 +5,23 @@ Subject: [PATCH] replace ChunkPos with long
 
 
 diff --git a/src/main/java/com/infernalsuite/aswm/AdvancedSlimePaper.java b/src/main/java/com/infernalsuite/aswm/AdvancedSlimePaper.java
-index 50350820d228e3656c569176aafd2cc534c17c15..72ae13b9f5f7db25a1a76b2f3855d37c44d8fcbd 100644
+index 50350820d228e3656c569176aafd2cc534c17c15..280750cd9872210cc9043deea71f76758c2925fd 100644
 --- a/src/main/java/com/infernalsuite/aswm/AdvancedSlimePaper.java
 +++ b/src/main/java/com/infernalsuite/aswm/AdvancedSlimePaper.java
-@@ -168,7 +168,7 @@ public class AdvancedSlimePaper implements AdvancedSlimePaperAPI {
+@@ -17,6 +17,7 @@ import com.infernalsuite.aswm.serialization.slime.SlimeSerializer;
+ import com.infernalsuite.aswm.serialization.slime.reader.SlimeWorldReaderRegistry;
+ import com.infernalsuite.aswm.skeleton.SkeletonSlimeWorld;
+ import com.infernalsuite.aswm.util.NmsUtil;
++import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+ import net.minecraft.server.level.ServerLevel;
+ import org.bukkit.Bukkit;
+ import org.bukkit.World;
+@@ -168,7 +169,7 @@ public class AdvancedSlimePaper implements AdvancedSlimePaperAPI {
          Objects.requireNonNull(worldName, "World name cannot be null");
          Objects.requireNonNull(propertyMap, "Properties cannot be null");
  
 -        return new SkeletonSlimeWorld(worldName, loader, readOnly, Map.of(), new CompoundTag("", new CompoundMap()), propertyMap, BRIDGE_INSTANCE.getCurrentVersion());
-+        return new SkeletonSlimeWorld(worldName, loader, readOnly, new it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap<>(0), new CompoundTag("", new CompoundMap()), propertyMap, BRIDGE_INSTANCE.getCurrentVersion());
++        return new SkeletonSlimeWorld(worldName, loader, readOnly, new Long2ObjectOpenHashMap<>(0), new CompoundTag("", new CompoundMap()), propertyMap, BRIDGE_INSTANCE.getCurrentVersion());
      }
  
      @Override


### PR DESCRIPTION
This PR replaces the chunk position object with a long, as you can see in the benchmark results below, it makes adding and getting of chunks more performant, and there are fewer objects in the heap, which also reduces the load on the GC.

> Benchmark                       Mode  Cnt        Score       Error  Units
> ChunkPosAdd.chunkPosLong       thrpt    5   376826,486 ± 13855,153  ops/s
> ChunkPosAdd.chunkPosObject     thrpt    5   187344,894 ± 12827,890  ops/s
> ChunkPosGet.chunkPosLong       thrpt    5  1053721,893 ± 75300,163  ops/s
> ChunkPosGet.chunkPosObject     thrpt    5   852351,543 ± 77379,401  ops/s
> ChunkPosRemove.chunkPosLong    thrpt    5  2114315,680 ± 96877,805  ops/s
> ChunkPosRemove.chunkPosObject  thrpt    5  4645570,885 ± 46174,424  ops/s
> 