### PR TITLE
Don't create a new config for each slime world

### DIFF
--- a/api/src/main/java/com/infernalsuite/aswm/api/world/properties/SlimeProperties.java
+++ b/api/src/main/java/com/infernalsuite/aswm/api/world/properties/SlimeProperties.java
@@ -105,5 +105,7 @@ public class SlimeProperties {
     @ApiStatus.Experimental
     public static final SlimeProperty<Integer> CHUNK_SECTION_MAX = new SlimePropertyInt("chunkSectionMin", 19);
 
+    @ApiStatus.Experimental
+    public static final SlimeProperty<Boolean> USE_CACHED_CONFIG = new SlimePropertyBoolean("useCachedConfig", false);
 
 }

--- a/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonSlimeWorld.java
+++ b/core/src/main/java/com/infernalsuite/aswm/skeleton/SkeletonSlimeWorld.java
@@ -1,6 +1,7 @@
 package com.infernalsuite.aswm.skeleton;
 
 import com.flowpowered.nbt.CompoundTag;
+import com.flowpowered.nbt.StringTag;
 import com.infernalsuite.aswm.Util;
 import com.infernalsuite.aswm.api.exceptions.WorldAlreadyExistsException;
 import com.infernalsuite.aswm.api.loaders.SlimeLoader;
@@ -119,6 +120,8 @@ public final class SkeletonSlimeWorld implements SlimeWorld {
         }
 
         SlimeWorld cloned = SkeletonCloning.fullClone(worldName, this, loader);
+        cloned.getExtraData().getValue().put(new StringTag("clonedFrom", this.name));
+
         if (loader != null) {
             loader.saveWorld(worldName, SlimeSerializer.serialize(cloned));
         }

--- a/patches/server/0016-Speed-up-world-loading.patch
+++ b/patches/server/0016-Speed-up-world-loading.patch
@@ -5,8 +5,88 @@ Subject: [PATCH] Speed up world loading
 
 Don't create a new config for each slime world
 
+diff --git a/src/main/java/com/infernalsuite/aswm/AdvancedSlimePaper.java b/src/main/java/com/infernalsuite/aswm/AdvancedSlimePaper.java
+index 85a5b184a1795fe3756596634e883757a980525b..2a246f47117a36d5b58c93e5a59cb79a6fd72029 100644
+--- a/src/main/java/com/infernalsuite/aswm/AdvancedSlimePaper.java
++++ b/src/main/java/com/infernalsuite/aswm/AdvancedSlimePaper.java
+@@ -17,6 +17,7 @@ import com.infernalsuite.aswm.serialization.slime.SlimeSerializer;
+ import com.infernalsuite.aswm.serialization.slime.reader.SlimeWorldReaderRegistry;
+ import com.infernalsuite.aswm.skeleton.SkeletonSlimeWorld;
+ import com.infernalsuite.aswm.util.NmsUtil;
++import io.papermc.paper.configuration.WorldConfiguration;
+ import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+ import net.minecraft.server.level.ServerLevel;
+ import org.bukkit.Bukkit;
+@@ -26,6 +27,7 @@ import org.bukkit.event.world.WorldLoadEvent;
+ import org.slf4j.Logger;
+ import org.slf4j.LoggerFactory;
+ import org.spigotmc.AsyncCatcher;
++import org.spigotmc.SpigotWorldConfig;
+ 
+ import java.io.File;
+ import java.io.IOException;
+@@ -43,6 +45,9 @@ public class AdvancedSlimePaper implements AdvancedSlimePaperAPI {
+ 
+     private final Map<String, SlimeWorld> loadedWorlds = new ConcurrentHashMap<>();
+ 
++    private final Map<String, WorldConfiguration> cachedPaperConfigs = new ConcurrentHashMap<>();
++    private final Map<String, SpigotWorldConfig> cachedSpigotConfigs = new ConcurrentHashMap<>();
++
+     static {
+         System.setProperty("org.slf4j.simpleLogger.showShortLogName", "true");
+     }
+@@ -240,5 +245,15 @@ public class AdvancedSlimePaper implements AdvancedSlimePaperAPI {
+ 
+     public void onWorldUnload(String name) {
+         this.loadedWorlds.remove(name);
++        this.cachedPaperConfigs.remove(name);
++        this.cachedSpigotConfigs.remove(name);
++    }
++
++    public Map<String, WorldConfiguration> getCachedPaperConfigs() {
++        return cachedPaperConfigs;
++    }
++
++    public Map<String, SpigotWorldConfig> getCachedSpigotConfigs() {
++        return cachedSpigotConfigs;
+     }
+ }
+diff --git a/src/main/java/com/infernalsuite/aswm/SlimeNMSBridgeImpl.java b/src/main/java/com/infernalsuite/aswm/SlimeNMSBridgeImpl.java
+index 87b6ee19fd165bde2db3a57545c58251dc6bad22..0709ce1720137963d06de757eefc2f5786dc4df6 100644
+--- a/src/main/java/com/infernalsuite/aswm/SlimeNMSBridgeImpl.java
++++ b/src/main/java/com/infernalsuite/aswm/SlimeNMSBridgeImpl.java
+@@ -4,6 +4,7 @@ import ca.spottedleaf.dataconverter.converters.DataConverter;
+ import ca.spottedleaf.dataconverter.minecraft.datatypes.MCTypeRegistry;
+ import ca.spottedleaf.dataconverter.types.nbt.NBTMapType;
+ import com.flowpowered.nbt.CompoundMap;
++import com.flowpowered.nbt.StringTag;
+ import com.infernalsuite.aswm.api.SlimeNMSBridge;
+ import com.infernalsuite.aswm.api.world.SlimeWorld;
+ import com.infernalsuite.aswm.api.world.SlimeWorldInstance;
+@@ -42,6 +43,7 @@ import org.jetbrains.annotations.Nullable;
+ import java.io.IOException;
+ import java.util.Locale;
+ import java.util.Map;
++import java.util.Optional;
+ 
+ public class SlimeNMSBridgeImpl implements SlimeNMSBridge {
+ 
+@@ -167,6 +169,13 @@ public class SlimeNMSBridgeImpl implements SlimeNMSBridge {
+         }
+ 
+         SlimeLevelInstance server = createCustomWorld(slimeWorld, dimensionOverride);
++
++        Optional<StringTag> tag = slimeWorld.getExtraData().getAsStringTag("clonedFrom");
++        if (tag.isEmpty()) {
++            AdvancedSlimePaper.instance().getCachedPaperConfigs().put(slimeWorld.getName(), server.paperConfig());
++            AdvancedSlimePaper.instance().getCachedSpigotConfigs().put(slimeWorld.getName(), server.spigotConfig);
++        }
++
+         registerWorld(server);
+         return server.getSlimeInstance();
+     }
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 340e996e9e5a4f8b6635511b3d7ce387df55611a..f5fa7a393567f6768d8134f4035db65cc22a63c8 100644
+index 5aae3c7692a6e4bc04b843878da063f6d2a5c7f2..bb62fdd27ac881ff90ab28e3445e6c36c4549d43 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -3,6 +3,7 @@ package net.minecraft.server.level;
@@ -17,7 +97,7 @@ index 340e996e9e5a4f8b6635511b3d7ce387df55611a..f5fa7a393567f6768d8134f4035db65c
  import com.mojang.datafixers.DataFixer;
  import com.mojang.datafixers.util.Pair;
  import com.mojang.logging.LogUtils;
-@@ -544,7 +545,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ca.spottedleaf.
+@@ -511,7 +512,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ca.spottedleaf.
          // Holder holder = worlddimension.type(); // CraftBukkit - decompile error
  
          // Objects.requireNonNull(minecraftserver); // CraftBukkit - decompile error
@@ -27,35 +107,42 @@ index 340e996e9e5a4f8b6635511b3d7ce387df55611a..f5fa7a393567f6768d8134f4035db65c
          this.convertable = convertable_conversionsession;
          this.uuid = WorldUUID.getUUID(convertable_conversionsession.levelDirectory.path().toFile());
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index b16c3beda0fc7d7d06cfc82f450165096a88bade..d6c8e2e27ae4f6964922f514809f7283ffa3ece6 100644
+index e2a0487089eb5a7bdc1433e4c75f69d8e9f9d5f9..fdf49f560492462dacd74836956cd67971dc429a 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -1,6 +1,7 @@
+@@ -1,11 +1,12 @@
  package net.minecraft.world.level;
  
++import com.flowpowered.nbt.StringTag;
  import com.google.common.collect.Lists;
++import com.infernalsuite.aswm.AdvancedSlimePaper;
 +import com.infernalsuite.aswm.api.world.properties.SlimeProperties;
  import com.mojang.serialization.Codec;
  import java.io.IOException;
- import java.util.Iterator;
-@@ -642,9 +643,23 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
+-import java.util.Iterator;
+-import java.util.List;
+-import java.util.Objects;
++import java.util.*;
+ import java.util.function.Consumer;
+ import java.util.function.Predicate;
+ import java.util.function.Supplier;
+@@ -684,9 +685,22 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
      }
-     // Paper end - optimise collisions
+     // Paper end - optimise random ticking
  
 -    protected Level(WritableLevelData worlddatamutable, ResourceKey<Level> resourcekey, RegistryAccess iregistrycustom, Holder<DimensionType> holder, Supplier<ProfilerFiller> supplier, boolean flag, boolean flag1, long i, int j, org.bukkit.generator.ChunkGenerator gen, org.bukkit.generator.BiomeProvider biomeProvider, org.bukkit.World.Environment env, java.util.function.Function<org.spigotmc.SpigotWorldConfig, io.papermc.paper.configuration.WorldConfiguration> paperWorldConfigCreator, java.util.concurrent.Executor executor) { // Paper - create paper world config & Anti-Xray
 -        this.spigotConfig = new org.spigotmc.SpigotWorldConfig(((net.minecraft.world.level.storage.PrimaryLevelData) worlddatamutable).getLevelName()); // Spigot
 -        this.paperConfig = paperWorldConfigCreator.apply(this.spigotConfig); // Paper - create paper world config
 +    protected Level(com.infernalsuite.aswm.level.SlimeBootstrap bootstrap, WritableLevelData worlddatamutable, ResourceKey<Level> resourcekey, RegistryAccess iregistrycustom, Holder<DimensionType> holder, Supplier<ProfilerFiller> supplier, boolean flag, boolean flag1, long i, int j, org.bukkit.generator.ChunkGenerator gen, org.bukkit.generator.BiomeProvider biomeProvider, org.bukkit.World.Environment env, java.util.function.Function<org.spigotmc.SpigotWorldConfig, io.papermc.paper.configuration.WorldConfiguration> paperWorldConfigCreator, java.util.concurrent.Executor executor) { // Paper - create paper world config & Anti-Xray
 +        if (bootstrap != null && bootstrap.initial().getPropertyMap().getValue(SlimeProperties.USE_CACHED_CONFIG)) {
-+            Iterable<ServerLevel> levels = net.minecraft.server.dedicated.DedicatedServer.getServer().getAllLevels();
-+            Iterator<ServerLevel> levelIterator = levels.iterator();
-+            if (levelIterator.hasNext()) {
-+                ServerLevel foundLevel = levelIterator.next();
-+                this.spigotConfig = foundLevel.spigotConfig;
-+                this.paperConfig = foundLevel.paperConfig();
++            Optional<StringTag> optional = bootstrap.initial().getExtraData().getAsStringTag("clonedFrom");
++            if (optional.isPresent()) {
++                String clonedFrom = optional.get().getValue();
++                this.spigotConfig = AdvancedSlimePaper.instance().getCachedSpigotConfigs().get(clonedFrom);
++                this.paperConfig = AdvancedSlimePaper.instance().getCachedPaperConfigs().get(clonedFrom);
 +            } else {
-+                this.spigotConfig = new org.spigotmc.SpigotWorldConfig(((net.minecraft.world.level.storage.PrimaryLevelData) worlddatamutable).getLevelName());
-+                this.paperConfig = paperWorldConfigCreator.apply(this.spigotConfig);
++                this.spigotConfig = new org.spigotmc.SpigotWorldConfig(((net.minecraft.world.level.storage.PrimaryLevelData) worlddatamutable).getLevelName()); // Spigot
++                this.paperConfig = paperWorldConfigCreator.apply(this.spigotConfig); // Paper - create paper world config
 +            }
 +        } else {
 +            this.spigotConfig = new org.spigotmc.SpigotWorldConfig(((net.minecraft.world.level.storage.PrimaryLevelData) worlddatamutable).getLevelName()); // Spigot

--- a/patches/server/0016-Speed-up-world-loading.patch
+++ b/patches/server/0016-Speed-up-world-loading.patch
@@ -27,7 +27,7 @@ index 340e996e9e5a4f8b6635511b3d7ce387df55611a..f5fa7a393567f6768d8134f4035db65c
          this.convertable = convertable_conversionsession;
          this.uuid = WorldUUID.getUUID(convertable_conversionsession.levelDirectory.path().toFile());
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index b16c3beda0fc7d7d06cfc82f450165096a88bade..be4b9e38401d222f2a237e237bdecc2d83fdf497 100644
+index b16c3beda0fc7d7d06cfc82f450165096a88bade..d6c8e2e27ae4f6964922f514809f7283ffa3ece6 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -1,6 +1,7 @@
@@ -38,7 +38,7 @@ index b16c3beda0fc7d7d06cfc82f450165096a88bade..be4b9e38401d222f2a237e237bdecc2d
  import com.mojang.serialization.Codec;
  import java.io.IOException;
  import java.util.Iterator;
-@@ -642,9 +643,20 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
+@@ -642,9 +643,23 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
      }
      // Paper end - optimise collisions
  
@@ -53,6 +53,9 @@ index b16c3beda0fc7d7d06cfc82f450165096a88bade..be4b9e38401d222f2a237e237bdecc2d
 +                ServerLevel foundLevel = levelIterator.next();
 +                this.spigotConfig = foundLevel.spigotConfig;
 +                this.paperConfig = foundLevel.paperConfig();
++            } else {
++                this.spigotConfig = new org.spigotmc.SpigotWorldConfig(((net.minecraft.world.level.storage.PrimaryLevelData) worlddatamutable).getLevelName());
++                this.paperConfig = paperWorldConfigCreator.apply(this.spigotConfig);
 +            }
 +        } else {
 +            this.spigotConfig = new org.spigotmc.SpigotWorldConfig(((net.minecraft.world.level.storage.PrimaryLevelData) worlddatamutable).getLevelName()); // Spigot

--- a/patches/server/0016-Speed-up-world-loading.patch
+++ b/patches/server/0016-Speed-up-world-loading.patch
@@ -1,0 +1,57 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: jtJava <ilovefuud@gmail.com>
+Date: Thu, 25 Jul 2024 04:36:04 -0500
+Subject: [PATCH] Speed up world loading
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
+index 340e996e9e5a4f8b6635511b3d7ce387df55611a..d806827a7da96c0a8d6571ec0285ff8e073abf8b 100644
+--- a/src/main/java/net/minecraft/server/level/ServerLevel.java
++++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
+@@ -544,7 +544,18 @@ public class ServerLevel extends Level implements WorldGenLevel, ca.spottedleaf.
+         // Holder holder = worlddimension.type(); // CraftBukkit - decompile error
+ 
+         // Objects.requireNonNull(minecraftserver); // CraftBukkit - decompile error
+-        super(iworlddataserver, resourcekey, minecraftserver.registryAccess(), worlddimension.type(), minecraftserver::getProfiler, false, flag, i, minecraftserver.getMaxChainedNeighborUpdates(), gen, biomeProvider, env, spigotConfig -> minecraftserver.paperConfigurations.createWorldConfig(io.papermc.paper.configuration.PaperConfigurations.createWorldContextMap(convertable_conversionsession.levelDirectory.path(), iworlddataserver.getLevelName(), resourcekey.location(), spigotConfig, minecraftserver.registryAccess(), iworlddataserver.getGameRules())), executor); // Paper - create paper world configs; Async-Anti-Xray: Pass executor
++        super(iworlddataserver, resourcekey, minecraftserver.registryAccess(), worlddimension.type(), minecraftserver::getProfiler, false, flag, i, minecraftserver.getMaxChainedNeighborUpdates(), gen, biomeProvider, env,
++                spigotConfig ->
++                {
++                    Iterable<ServerLevel> levels = net.minecraft.server.dedicated.DedicatedServer.getServer().getAllLevels();
++                    Iterator<ServerLevel> levelIterator = levels.iterator();
++                    if (levelIterator.hasNext()) {
++                        return levelIterator.next().paperConfig();
++                    } else {
++                        return minecraftserver.paperConfigurations.createWorldConfig(io.papermc.paper.configuration.PaperConfigurations.createWorldContextMap(convertable_conversionsession.levelDirectory.path(), iworlddataserver.getLevelName(), resourcekey.location(), spigotConfig, minecraftserver.registryAccess(), iworlddataserver.getGameRules()));
++                    }
++                },
++                executor); // Paper - create paper world configs; Async-Anti-Xray: Pass executor
+         this.pvpMode = minecraftserver.isPvpAllowed();
+         this.convertable = convertable_conversionsession;
+         this.uuid = WorldUUID.getUUID(convertable_conversionsession.levelDirectory.path().toFile());
+diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
+index db9c812cf7267adf0bfd8be7368140e91245d640..d7f7a6c7a604bb4473ae71be8004fd8ceb5f09b1 100644
+--- a/src/main/java/org/spigotmc/SpigotConfig.java
++++ b/src/main/java/org/spigotmc/SpigotConfig.java
+@@ -124,14 +124,14 @@ public class SpigotConfig
+         SpigotConfig.save();
+     }
+     public static void save() {
+-        // Paper end
+-        try
+-        {
+-            SpigotConfig.config.save( SpigotConfig.CONFIG_FILE );
+-        } catch ( IOException ex )
+-        {
+-            Bukkit.getLogger().log( Level.SEVERE, "Could not save " + SpigotConfig.CONFIG_FILE, ex );
+-        }
++//        // Paper end
++//        try
++//        {
++//            SpigotConfig.config.save( SpigotConfig.CONFIG_FILE );
++//        } catch ( IOException ex )
++//        {
++//            Bukkit.getLogger().log( Level.SEVERE, "Could not save " + SpigotConfig.CONFIG_FILE, ex );
++//        }
+     }
+ 
+     private static void set(String path, Object val)

--- a/patches/server/0016-Speed-up-world-loading.patch
+++ b/patches/server/0016-Speed-up-world-loading.patch
@@ -3,55 +3,62 @@ From: jtJava <ilovefuud@gmail.com>
 Date: Thu, 25 Jul 2024 04:36:04 -0500
 Subject: [PATCH] Speed up world loading
 
+Don't create a new config for each slime world
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 340e996e9e5a4f8b6635511b3d7ce387df55611a..d806827a7da96c0a8d6571ec0285ff8e073abf8b 100644
+index 340e996e9e5a4f8b6635511b3d7ce387df55611a..f5fa7a393567f6768d8134f4035db65cc22a63c8 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -544,7 +544,18 @@ public class ServerLevel extends Level implements WorldGenLevel, ca.spottedleaf.
+@@ -3,6 +3,7 @@ package net.minecraft.server.level;
+ import com.google.common.annotations.VisibleForTesting;
+ import co.aikar.timings.TimingHistory; // Paper
+ import com.google.common.collect.Lists;
++import com.infernalsuite.aswm.api.world.properties.SlimeProperties;
+ import com.mojang.datafixers.DataFixer;
+ import com.mojang.datafixers.util.Pair;
+ import com.mojang.logging.LogUtils;
+@@ -544,7 +545,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ca.spottedleaf.
          // Holder holder = worlddimension.type(); // CraftBukkit - decompile error
  
          // Objects.requireNonNull(minecraftserver); // CraftBukkit - decompile error
 -        super(iworlddataserver, resourcekey, minecraftserver.registryAccess(), worlddimension.type(), minecraftserver::getProfiler, false, flag, i, minecraftserver.getMaxChainedNeighborUpdates(), gen, biomeProvider, env, spigotConfig -> minecraftserver.paperConfigurations.createWorldConfig(io.papermc.paper.configuration.PaperConfigurations.createWorldContextMap(convertable_conversionsession.levelDirectory.path(), iworlddataserver.getLevelName(), resourcekey.location(), spigotConfig, minecraftserver.registryAccess(), iworlddataserver.getGameRules())), executor); // Paper - create paper world configs; Async-Anti-Xray: Pass executor
-+        super(iworlddataserver, resourcekey, minecraftserver.registryAccess(), worlddimension.type(), minecraftserver::getProfiler, false, flag, i, minecraftserver.getMaxChainedNeighborUpdates(), gen, biomeProvider, env,
-+                spigotConfig ->
-+                {
-+                    Iterable<ServerLevel> levels = net.minecraft.server.dedicated.DedicatedServer.getServer().getAllLevels();
-+                    Iterator<ServerLevel> levelIterator = levels.iterator();
-+                    if (levelIterator.hasNext()) {
-+                        return levelIterator.next().paperConfig();
-+                    } else {
-+                        return minecraftserver.paperConfigurations.createWorldConfig(io.papermc.paper.configuration.PaperConfigurations.createWorldContextMap(convertable_conversionsession.levelDirectory.path(), iworlddataserver.getLevelName(), resourcekey.location(), spigotConfig, minecraftserver.registryAccess(), iworlddataserver.getGameRules()));
-+                    }
-+                },
-+                executor); // Paper - create paper world configs; Async-Anti-Xray: Pass executor
++        super(bootstrap, iworlddataserver, resourcekey, minecraftserver.registryAccess(), worlddimension.type(), minecraftserver::getProfiler, false, flag, i, minecraftserver.getMaxChainedNeighborUpdates(), gen, biomeProvider, env, spigotConfig -> minecraftserver.paperConfigurations.createWorldConfig(io.papermc.paper.configuration.PaperConfigurations.createWorldContextMap(convertable_conversionsession.levelDirectory.path(), iworlddataserver.getLevelName(), resourcekey.location(), spigotConfig, minecraftserver.registryAccess(), iworlddataserver.getGameRules())), executor); // Paper - create paper world configs; Async-Anti-Xray: Pass executor
          this.pvpMode = minecraftserver.isPvpAllowed();
          this.convertable = convertable_conversionsession;
          this.uuid = WorldUUID.getUUID(convertable_conversionsession.levelDirectory.path().toFile());
-diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
-index db9c812cf7267adf0bfd8be7368140e91245d640..d7f7a6c7a604bb4473ae71be8004fd8ceb5f09b1 100644
---- a/src/main/java/org/spigotmc/SpigotConfig.java
-+++ b/src/main/java/org/spigotmc/SpigotConfig.java
-@@ -124,14 +124,14 @@ public class SpigotConfig
-         SpigotConfig.save();
-     }
-     public static void save() {
--        // Paper end
--        try
--        {
--            SpigotConfig.config.save( SpigotConfig.CONFIG_FILE );
--        } catch ( IOException ex )
--        {
--            Bukkit.getLogger().log( Level.SEVERE, "Could not save " + SpigotConfig.CONFIG_FILE, ex );
--        }
-+//        // Paper end
-+//        try
-+//        {
-+//            SpigotConfig.config.save( SpigotConfig.CONFIG_FILE );
-+//        } catch ( IOException ex )
-+//        {
-+//            Bukkit.getLogger().log( Level.SEVERE, "Could not save " + SpigotConfig.CONFIG_FILE, ex );
-+//        }
-     }
+diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
+index b16c3beda0fc7d7d06cfc82f450165096a88bade..be4b9e38401d222f2a237e237bdecc2d83fdf497 100644
+--- a/src/main/java/net/minecraft/world/level/Level.java
++++ b/src/main/java/net/minecraft/world/level/Level.java
+@@ -1,6 +1,7 @@
+ package net.minecraft.world.level;
  
-     private static void set(String path, Object val)
+ import com.google.common.collect.Lists;
++import com.infernalsuite.aswm.api.world.properties.SlimeProperties;
+ import com.mojang.serialization.Codec;
+ import java.io.IOException;
+ import java.util.Iterator;
+@@ -642,9 +643,20 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
+     }
+     // Paper end - optimise collisions
+ 
+-    protected Level(WritableLevelData worlddatamutable, ResourceKey<Level> resourcekey, RegistryAccess iregistrycustom, Holder<DimensionType> holder, Supplier<ProfilerFiller> supplier, boolean flag, boolean flag1, long i, int j, org.bukkit.generator.ChunkGenerator gen, org.bukkit.generator.BiomeProvider biomeProvider, org.bukkit.World.Environment env, java.util.function.Function<org.spigotmc.SpigotWorldConfig, io.papermc.paper.configuration.WorldConfiguration> paperWorldConfigCreator, java.util.concurrent.Executor executor) { // Paper - create paper world config & Anti-Xray
+-        this.spigotConfig = new org.spigotmc.SpigotWorldConfig(((net.minecraft.world.level.storage.PrimaryLevelData) worlddatamutable).getLevelName()); // Spigot
+-        this.paperConfig = paperWorldConfigCreator.apply(this.spigotConfig); // Paper - create paper world config
++    protected Level(com.infernalsuite.aswm.level.SlimeBootstrap bootstrap, WritableLevelData worlddatamutable, ResourceKey<Level> resourcekey, RegistryAccess iregistrycustom, Holder<DimensionType> holder, Supplier<ProfilerFiller> supplier, boolean flag, boolean flag1, long i, int j, org.bukkit.generator.ChunkGenerator gen, org.bukkit.generator.BiomeProvider biomeProvider, org.bukkit.World.Environment env, java.util.function.Function<org.spigotmc.SpigotWorldConfig, io.papermc.paper.configuration.WorldConfiguration> paperWorldConfigCreator, java.util.concurrent.Executor executor) { // Paper - create paper world config & Anti-Xray
++        if (bootstrap != null && bootstrap.initial().getPropertyMap().getValue(SlimeProperties.USE_CACHED_CONFIG)) {
++            Iterable<ServerLevel> levels = net.minecraft.server.dedicated.DedicatedServer.getServer().getAllLevels();
++            Iterator<ServerLevel> levelIterator = levels.iterator();
++            if (levelIterator.hasNext()) {
++                ServerLevel foundLevel = levelIterator.next();
++                this.spigotConfig = foundLevel.spigotConfig;
++                this.paperConfig = foundLevel.paperConfig();
++            }
++        } else {
++            this.spigotConfig = new org.spigotmc.SpigotWorldConfig(((net.minecraft.world.level.storage.PrimaryLevelData) worlddatamutable).getLevelName()); // Spigot
++            this.paperConfig = paperWorldConfigCreator.apply(this.spigotConfig); // Paper - create paper world config
++        }
++
+         this.generator = gen;
+         this.world = new CraftWorld((ServerLevel) this, gen, biomeProvider, env);
+ 


### PR DESCRIPTION
Meant to fix #110 
Testing was done with a small 100x100x64 world, cloning done on main thread but pretty sure it can be offloaded.

Results: 2177 ms -> 1294 ms

Before: 
https://spark.lucko.me/46jHRGoWHt
https://mclo.gs/eZfDIFC

After:
https://spark.lucko.me/DspcQn4jQL
https://mclo.gs/eDOs3Jc

Testing code: 
![image](https://github.com/user-attachments/assets/86cf9228-bb07-4f25-8a28-59efca06b586)
