### PR TITLE
Update to the newest paper build and resolve chunk issues

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ group=com.infernalsuite.aswm
 version=1.21.3-R0.1-SNAPSHOT
 
 mcVersion=1.21.3
-paperRef=92131adaf2687f350b2f8dc7cd1213ab833d1831
+paperRef=da7138233f6392e791d790d1c3407414c855f9c2
 
 org.gradle.caching=true
 org.gradle.parallel=true

--- a/patches/api/0001-Slime-World-Manager.patch
+++ b/patches/api/0001-Slime-World-Manager.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Slime World Manager
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 254fd96d3950b4494c7e43547b00b5175ee53c93..911879d193907e65e0e0e50b8292d2394b934d42 100644
+index e29e5024fa693baae469d47fe77b57118f14627c..4da167f928789c1b5d55da2749a94e44912492ad 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -1,3 +1,5 @@
@@ -14,7 +14,7 @@ index 254fd96d3950b4494c7e43547b00b5175ee53c93..911879d193907e65e0e0e50b8292d239
  plugins {
      `java-library`
      `maven-publish`
-@@ -29,6 +31,7 @@ configurations.api {
+@@ -41,6 +43,7 @@ abstract class MockitoAgentProvider : CommandLineArgumentProvider {
  dependencies {
      api("com.mojang:brigadier:1.2.9") // Paper - Brigadier command api
      // api dependencies are listed transitively to API consumers

--- a/patches/server/0001-Build-Changes.patch
+++ b/patches/server/0001-Build-Changes.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Build Changes
 Update shadow plugin
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 9b3a6b336cb1344d4e74e0e4f7c50ffd1e1b8955..a615e8dc49bbe84b4baf2fc3cfcce7372210310a 100644
+index faf3e3fd72e8c915e7a4803dacbe1bb576c6663e..e90c79790c40afb67364fed615be2384c30d73d0 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -4,6 +4,7 @@ import java.time.Instant
@@ -17,8 +17,8 @@ index 9b3a6b336cb1344d4e74e0e4f7c50ffd1e1b8955..a615e8dc49bbe84b4baf2fc3cfcce737
  }
  
  val log4jPlugins = sourceSets.create("log4jPlugins")
-@@ -13,7 +14,13 @@ configurations.named(log4jPlugins.compileClasspathConfigurationName) {
- val alsoShade: Configuration by configurations.creating
+@@ -25,7 +26,13 @@ abstract class MockitoAgentProvider : CommandLineArgumentProvider {
+ // Paper end - configure mockito agent that is needed in newer java versions
  
  dependencies {
 -    implementation(project(":paper-api"))
@@ -30,9 +30,9 @@ index 9b3a6b336cb1344d4e74e0e4f7c50ffd1e1b8955..a615e8dc49bbe84b4baf2fc3cfcce737
 +    }
 +    // ASWM end
      // Paper start
-     implementation("org.jline:jline-terminal-jansi:3.21.0")
-     implementation("net.minecrell:terminalconsoleappender:1.3.0")
-@@ -85,14 +92,14 @@ tasks.jar {
+     implementation("org.jline:jline-terminal-ffm:3.27.1") // use ffm on java 22+
+     implementation("org.jline:jline-terminal-jni:3.27.1") // fall back to jni on java 21
+@@ -99,14 +106,14 @@ tasks.jar {
          val gitBranch = git("rev-parse", "--abbrev-ref", "HEAD").getText().trim() // Paper
          attributes(
              "Main-Class" to "org.bukkit.craftbukkit.Main",
@@ -52,7 +52,7 @@ index 9b3a6b336cb1344d4e74e0e4f7c50ffd1e1b8955..a615e8dc49bbe84b4baf2fc3cfcce737
              "Build-Number" to (build ?: ""),
              "Build-Time" to Instant.now().toString(),
              "Git-Branch" to gitBranch, // Paper
-@@ -153,7 +160,7 @@ fun TaskContainer.registerRunTask(
+@@ -172,7 +179,7 @@ fun TaskContainer.registerRunTask(
      name: String,
      block: JavaExec.() -> Unit
  ): TaskProvider<JavaExec> = register<JavaExec>(name) {
@@ -75,7 +75,7 @@ index b3c993a790fc3fab6a408c731deb297f74c959ce..0bbd557602932b67212b8951ef769bbc
      public FullChunkStatus status;
      public final ChunkData chunkData;
 diff --git a/src/main/java/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/ChunkHolderManager.java b/src/main/java/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/ChunkHolderManager.java
-index a0e5fc2eff605e17704f0726d20e79cbb3d88d6d..e47b0f145d132fb43c0d6a4e165c3a6782b3ed09 100644
+index 91a6f57f35fc1553159cca138a0619e703b2b014..07fee642805ac3ec6fce489a0b9050ddf941d932 100644
 --- a/src/main/java/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/ChunkHolderManager.java
 +++ b/src/main/java/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/ChunkHolderManager.java
 @@ -185,7 +185,8 @@ public final class ChunkHolderManager {
@@ -2073,7 +2073,7 @@ index 790bad0494454ca12ee152e3de6da3da634d9b20..2d6b062c4a3cf682d8e4cdbb7b7c84a7
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 64b56abf8900d0424100da460fc68ac964394793..52c6fd303e150377d0864139065219bda6a4f97f 100644
+index 663b4ecd520e82aa108d44f2d5c2a20cfc7bc01f..4d9b240534372103268a53712a13027ddd434071 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -288,7 +288,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -2085,7 +2085,7 @@ index 64b56abf8900d0424100da460fc68ac964394793..52c6fd303e150377d0864139065219bd
      private final CustomBossEvents customBossEvents;
      private final ServerFunctionManager functionManager;
      private boolean enforceWhitelist;
-@@ -559,51 +559,66 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -560,51 +560,66 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              if (dimensionKey == LevelStem.NETHER) {
                  if (this.server.getAllowNether()) {
                      dimension = -1;
@@ -2165,7 +2165,7 @@ index 64b56abf8900d0424100da460fc68ac964394793..52c6fd303e150377d0864139065219bd
                          MinecraftServer.LOGGER.warn("Could not create path for " + newWorld + "!");
                          MinecraftServer.LOGGER.info("---- Migration of old " + worldType + " folder failed ----");
                      }
-@@ -611,7 +626,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -612,7 +627,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
                  try {
                      worldSession = LevelStorageSource.createDefault(this.server.getWorldContainer().toPath()).validateAndCreateAccess(name, dimensionKey);
@@ -2175,10 +2175,10 @@ index 64b56abf8900d0424100da460fc68ac964394793..52c6fd303e150377d0864139065219bd
                  }
              }
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 3c711e1df57ac5b0f8795ebb12299d275792b1d4..ba52f75817f6c8a769d4ab0e169a3ffe6c500521 100644
+index 61a73a234d9bdd22958ae261b7d0359179f7a57b..b7ecd3556f71f25b88bea6aa488e2993c2ca0fcf 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-@@ -173,7 +173,11 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
+@@ -176,7 +176,11 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
      // Paper end - chunk tick iteration optimisations
  
  
@@ -2192,10 +2192,10 @@ index 3c711e1df57ac5b0f8795ebb12299d275792b1d4..ba52f75817f6c8a769d4ab0e169a3ffe
          this.mainThreadProcessor = new ServerChunkCache.MainThreadExecutor(world);
          this.mainThread = Thread.currentThread();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 5964d601c05176f48167cc92057a59e52a4da92b..56eb45b2df21acb4461e1d800280b39084ccd143 100644
+index 957cae6ddeba9efe3b55588567ae51e8b86b6a42..d414a0056ab27558440086ab373867bd7e28cdd2 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -588,8 +588,14 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -595,8 +595,14 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
      }
      // Paper end - lag compensation
  
@@ -2211,7 +2211,7 @@ index 5964d601c05176f48167cc92057a59e52a4da92b..56eb45b2df21acb4461e1d800280b390
          super(iworlddataserver, resourcekey, minecraftserver.registryAccess(), worlddimension.type(), false, flag, i, minecraftserver.getMaxChainedNeighborUpdates(), gen, biomeProvider, env, spigotConfig -> minecraftserver.paperConfigurations.createWorldConfig(io.papermc.paper.configuration.PaperConfigurations.createWorldContextMap(convertable_conversionsession.levelDirectory.path(), iworlddataserver.getLevelName(), resourcekey.location(), spigotConfig, minecraftserver.registryAccess(), iworlddataserver.getGameRules())), executor); // Paper - create paper world configs; Async-Anti-Xray: Pass executor
          this.pvpMode = minecraftserver.isPvpAllowed();
          this.convertable = convertable_conversionsession;
-@@ -616,6 +622,12 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -623,6 +629,12 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
              chunkgenerator = new org.bukkit.craftbukkit.generator.CustomChunkGenerator(this, chunkgenerator, gen);
          }
          // CraftBukkit end
@@ -2224,7 +2224,7 @@ index 5964d601c05176f48167cc92057a59e52a4da92b..56eb45b2df21acb4461e1d800280b390
          boolean flag2 = minecraftserver.forceSynchronousWrites();
          DataFixer datafixer = minecraftserver.getFixerUpper();
          EntityPersistentStorage<Entity> entitypersistentstorage = new EntityStorage(new SimpleRegionStorage(new RegionStorageInfo(convertable_conversionsession.getLevelId(), resourcekey, "entities"), convertable_conversionsession.getDimensionPath(resourcekey).resolve("entities"), datafixer, flag2, DataFixTypes.ENTITY_CHUNK), this, minecraftserver);
-@@ -626,7 +638,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -633,7 +645,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
          int k = this.spigotConfig.simulationDistance; // Spigot
          // Paper - rewrite chunk system
  
@@ -2233,7 +2233,7 @@ index 5964d601c05176f48167cc92057a59e52a4da92b..56eb45b2df21acb4461e1d800280b390
              return minecraftserver.overworld().getDataStorage();
          });
          this.chunkSource.getGeneratorState().ensureStructuresGenerated();
-@@ -685,6 +697,12 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -692,6 +704,12 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
          this.dragonFight = enderDragonFight;
      }
  

--- a/patches/server/0002-poi-data-loader.patch
+++ b/patches/server/0002-poi-data-loader.patch
@@ -44,10 +44,10 @@ index 41e652b568598926e838e81fdc338e51f8e97ef8..c32d52c68188dc1eb7feeac364cdc4ad
          try {
              //                if (data.tasks != null) {
 diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/SerializableChunkData.java b/src/main/java/net/minecraft/world/level/chunk/storage/SerializableChunkData.java
-index 057c92d182e643cebb1f27e296e0fc4b0e688bea..d558e53b91e38c55fe25273b468b1e8a480ecced 100644
+index 018b24d7611c3fd11536441431abf8f125850129..faf7f4f3bd1fbc91a40e5549a7a5520ea3eaec37 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/storage/SerializableChunkData.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/storage/SerializableChunkData.java
-@@ -357,6 +357,10 @@ public record SerializableChunkData(Registry<Biome> biomeRegistry, ChunkPos chun
+@@ -369,6 +369,10 @@ public record SerializableChunkData(Registry<Biome> biomeRegistry, ChunkPos chun
                  if (flag3) {
                      levellightengine.queueSectionData(LightLayer.SKY, sectionposition, serializablechunkdata_b.skyLight);
                  }

--- a/patches/server/0012-Compile-fixes.patch
+++ b/patches/server/0012-Compile-fixes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Compile fixes
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index f947b82537e5858dd0020a7a6fff48c54f3b49a3..316d03791a97af50f882c0271cbacf3d2a7af5b3 100644
+index 41ed3865710e9732f7662e1d3bf287ad9cf80c74..bb915dc69af63cab992a5b7f8654b5390340c89e 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -17,9 +17,6 @@ dependencies {
+@@ -29,9 +29,6 @@ dependencies {
      // ASWM start
      implementation(project(":slimeworldmanager-api"))
      implementation(project(":core"))
@@ -17,7 +17,7 @@ index f947b82537e5858dd0020a7a6fff48c54f3b49a3..316d03791a97af50f882c0271cbacf3d
 -    }
      // ASWM end
      // Paper start
-     implementation("org.jline:jline-terminal-jansi:3.21.0")
+     implementation("org.jline:jline-terminal-ffm:3.27.1") // use ffm on java 22+
 diff --git a/src/main/java/com/infernalsuite/aswm/level/NMSSlimeChunk.java b/src/main/java/com/infernalsuite/aswm/level/NMSSlimeChunk.java
 index e183ca25bf67a0519de7a91615fbcfc6ff45a56e..b295d159200e3bf0e48f851ac206b2e09b756bb2 100644
 --- a/src/main/java/com/infernalsuite/aswm/level/NMSSlimeChunk.java

--- a/patches/server/0013-Separate-plugin-and-server-rework-API-to-v3.patch
+++ b/patches/server/0013-Separate-plugin-and-server-rework-API-to-v3.patch
@@ -5,17 +5,17 @@ Subject: [PATCH] Separate plugin and server, rework API (to v3)
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index b9f1df889cf7d87f988aecf04b75c77da1152eb0..c323b9a523593dcfa4a5ec012c9c65887fcf3dce 100644
+index 22931927ac8c1fcdc45d44f8d4a898a44831039c..e10d95ce805d03fa43f526dc0a1a1123a67b4f0c 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -17,6 +17,7 @@ dependencies {
+@@ -29,6 +29,7 @@ dependencies {
      // ASWM start
      implementation(project(":slimeworldmanager-api"))
      implementation(project(":core"))
 +    implementation("commons-io:commons-io:2.11.0")
      // ASWM end
      // Paper start
-     implementation("org.jline:jline-terminal-jansi:3.21.0")
+     implementation("org.jline:jline-terminal-ffm:3.27.1") // use ffm on java 22+
 diff --git a/src/main/java/com/infernalsuite/aswm/AdvancedSlimePaper.java b/src/main/java/com/infernalsuite/aswm/AdvancedSlimePaper.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..719bfb548cfe69cbb726d95b68527bdf45f1eb52
@@ -706,7 +706,7 @@ index 26422904751647a061397ce978bba752149003cd..4940083475948eac4fc06446f7ee7e1e
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b185a9b474121b8a4067816b3c3c39270c2a202e..81ca05a02652c610a8a3c5054b0af82fe2a2bbdc 100644
+index ac8af406180bc680d46e8edc3da0fc2e5211345a..4936c074ad73d92f3b5ed6463126abb5017e221c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableList;
@@ -717,7 +717,7 @@ index b185a9b474121b8a4067816b3c3c39270c2a202e..81ca05a02652c610a8a3c5054b0af82f
  import com.mojang.authlib.GameProfile;
  import com.mojang.brigadier.StringReader;
  import com.mojang.brigadier.exceptions.CommandSyntaxException;
-@@ -1475,6 +1476,8 @@ public final class CraftServer implements Server {
+@@ -1487,6 +1488,8 @@ public final class CraftServer implements Server {
              return false;
          }
  

--- a/patches/server/0015-1.21-compatibility.patch
+++ b/patches/server/0015-1.21-compatibility.patch
@@ -281,10 +281,10 @@ index 4640baec5bed6c2d53cc0f8ca1d273cc115abe9b..589cb65f79bb05ee8c44b526c707e81d
      @Override
      public final FluidState getFluidIfLoaded(BlockPos blockposition) {
 diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/SerializableChunkData.java b/src/main/java/net/minecraft/world/level/chunk/storage/SerializableChunkData.java
-index d558e53b91e38c55fe25273b468b1e8a480ecced..c1e5a630d6cafca91398f55203994879bcac6fe4 100644
+index faf7f4f3bd1fbc91a40e5549a7a5520ea3eaec37..8832efbf9f68fb0466fdc9d6eb0d0acf5d5930dd 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/storage/SerializableChunkData.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/storage/SerializableChunkData.java
-@@ -457,7 +457,7 @@ public record SerializableChunkData(Registry<Biome> biomeRegistry, ChunkPos chun
+@@ -469,7 +469,7 @@ public record SerializableChunkData(Registry<Biome> biomeRegistry, ChunkPos chun
          SerializableChunkData.LOGGER.error("Recoverable errors when loading section [{}, {}, {}]: {}", new Object[]{chunkPos.x, y, chunkPos.z, message});
      }
  

--- a/patches/server/0017-fix-disable-dragon-fights.patch
+++ b/patches/server/0017-fix-disable-dragon-fights.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] fix disable dragon fights
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 56eb45b2df21acb4461e1d800280b39084ccd143..18d6aa9b37947b5eac7511da5d2e33b79be5be0c 100644
+index d414a0056ab27558440086ab373867bd7e28cdd2..36d0ce70ab1eaddf3354a9e2f8c86269cb319342 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -2,6 +2,7 @@ package net.minecraft.server.level;
@@ -16,7 +16,7 @@ index 56eb45b2df21acb4461e1d800280b39084ccd143..18d6aa9b37947b5eac7511da5d2e33b7
  import com.mojang.datafixers.DataFixer;
  import com.mojang.datafixers.util.Pair;
  import com.mojang.logging.LogUtils;
-@@ -656,7 +657,13 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -663,7 +664,13 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
          this.structureCheck = new StructureCheck(this.chunkSource.chunkScanner(), this.registryAccess(), minecraftserver.getStructureManager(), this.getTypeKey(), chunkgenerator, this.chunkSource.randomState(), this, chunkgenerator.getBiomeSource(), l, datafixer); // Paper - Fix missing CB diff
          this.structureManager = new StructureManager(this, this.serverLevelData.worldGenOptions(), this.structureCheck); // CraftBukkit
          if ((this.dimension() == Level.END && this.dimensionTypeRegistration().is(BuiltinDimensionTypes.END)) || env == org.bukkit.World.Environment.THE_END) { // CraftBukkit - Allow to create EnderDragonBattle in default and custom END

--- a/patches/server/0019-1.21.3-fixes.patch
+++ b/patches/server/0019-1.21.3-fixes.patch
@@ -264,10 +264,10 @@ index 6a5a8fbd8ee013828685495267283d9518d32d20..acb6ea84fbc40a6907edb237b834feeb
      }
  
 diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/SerializableChunkData.java b/src/main/java/net/minecraft/world/level/chunk/storage/SerializableChunkData.java
-index c1e5a630d6cafca91398f55203994879bcac6fe4..07808162fbd38dcfab0c298750323de318baa486 100644
+index 8832efbf9f68fb0466fdc9d6eb0d0acf5d5930dd..d03db9b8e78c795408b336beb53d6940a75ed759 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/storage/SerializableChunkData.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/storage/SerializableChunkData.java
-@@ -359,7 +359,7 @@ public record SerializableChunkData(Registry<Biome> biomeRegistry, ChunkPos chun
+@@ -371,7 +371,7 @@ public record SerializableChunkData(Registry<Biome> biomeRegistry, ChunkPos chun
                  }
  
                  if (world instanceof com.infernalsuite.aswm.level.SlimeLevelInstance) {

--- a/patches/server/0020-Fix-missing-chunks-entities-when-chunk-saving.patch
+++ b/patches/server/0020-Fix-missing-chunks-entities-when-chunk-saving.patch
@@ -5,22 +5,23 @@ Subject: [PATCH] Fix missing chunks & entities when chunk saving
 
 
 diff --git a/src/main/java/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/NewChunkHolder.java b/src/main/java/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/NewChunkHolder.java
-index bc0990458df745c92e5bc0530ff35ab992365b3a..ea8bd11050bb2811fff1a930bfb055fee55a274d 100644
+index bc0990458df745c92e5bc0530ff35ab992365b3a..682f293396ef34fdc6a61314827dc34f504c7777 100644
 --- a/src/main/java/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/NewChunkHolder.java
 +++ b/src/main/java/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/NewChunkHolder.java
-@@ -914,6 +914,12 @@ public final class NewChunkHolder {
-                 this.world.unload(levelChunk);
-             }
-         }
+@@ -897,6 +897,13 @@ public final class NewChunkHolder {
+ 
+         final boolean shouldLevelChunkNotSave = PlatformHooks.get().forceNoSave(chunk);
+ 
 +        // ASP start - Chunk unloading
 +        if (world instanceof com.infernalsuite.aswm.level.SlimeLevelInstance slime && chunk instanceof LevelChunk levelChunk) {
 +            //The custom entity slices need to be passed on for entities to be saved
 +            slime.onChunkUnloaded(levelChunk, entityChunk);
 +        }
 +        // ASP end - Chunk unloading
- 
-         // unload entity data
-         if (entityChunk != null) {
++
+         // unload chunk data
+         if (chunk != null) {
+             if (chunk instanceof LevelChunk levelChunk) {
 diff --git a/src/main/java/com/infernalsuite/aswm/level/NMSSlimeChunk.java b/src/main/java/com/infernalsuite/aswm/level/NMSSlimeChunk.java
 index cbcbbc8410b24daf685d74791ad80989d4830d7b..cdc4fd3a8767a3cb168ceb3088f4ae237fd9a11e 100644
 --- a/src/main/java/com/infernalsuite/aswm/level/NMSSlimeChunk.java

--- a/patches/server/0020-Fix-missing-chunks-entities-when-chunk-saving.patch
+++ b/patches/server/0020-Fix-missing-chunks-entities-when-chunk-saving.patch
@@ -1,0 +1,131 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: David Mayr <davidliebtkekse@gmail.com>
+Date: Thu, 5 Dec 2024 01:41:21 +0100
+Subject: [PATCH] Fix missing chunks & entities when chunk saving
+
+
+diff --git a/src/main/java/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/NewChunkHolder.java b/src/main/java/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/NewChunkHolder.java
+index bc0990458df745c92e5bc0530ff35ab992365b3a..ea8bd11050bb2811fff1a930bfb055fee55a274d 100644
+--- a/src/main/java/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/NewChunkHolder.java
++++ b/src/main/java/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/NewChunkHolder.java
+@@ -914,6 +914,12 @@ public final class NewChunkHolder {
+                 this.world.unload(levelChunk);
+             }
+         }
++        // ASP start - Chunk unloading
++        if (world instanceof com.infernalsuite.aswm.level.SlimeLevelInstance slime && chunk instanceof LevelChunk levelChunk) {
++            //The custom entity slices need to be passed on for entities to be saved
++            slime.onChunkUnloaded(levelChunk, entityChunk);
++        }
++        // ASP end - Chunk unloading
+ 
+         // unload entity data
+         if (entityChunk != null) {
+diff --git a/src/main/java/com/infernalsuite/aswm/level/NMSSlimeChunk.java b/src/main/java/com/infernalsuite/aswm/level/NMSSlimeChunk.java
+index cbcbbc8410b24daf685d74791ad80989d4830d7b..cdc4fd3a8767a3cb168ceb3088f4ae237fd9a11e 100644
+--- a/src/main/java/com/infernalsuite/aswm/level/NMSSlimeChunk.java
++++ b/src/main/java/com/infernalsuite/aswm/level/NMSSlimeChunk.java
+@@ -66,12 +66,19 @@ public class NMSSlimeChunk implements SlimeChunk {
+     private final CompoundTag extra;
+     private final CompoundTag upgradeData;
+ 
++    private final ChunkEntitySlices entitySlices;
++
+     public NMSSlimeChunk(LevelChunk chunk, SlimeChunk reference) {
++        this(chunk, reference, null);
++    }
++
++    public NMSSlimeChunk(LevelChunk chunk, SlimeChunk reference, ChunkEntitySlices slices) {
+         this.chunk = chunk;
+         this.extra = new CompoundTag("", new CompoundMap());
+         extra.getValue().put(Converter.convertTag("ChunkBukkitValues", chunk.persistentDataContainer.toTagCompound()));
+ 
+         this.upgradeData = reference == null ? null : reference.getUpgradeData();
++        this.entitySlices = slices;
+     }
+ 
+     @Override
+@@ -168,11 +175,7 @@ public class NMSSlimeChunk implements SlimeChunk {
+     public List<CompoundTag> getEntities() {
+         List<net.minecraft.nbt.CompoundTag> entities = new ArrayList<>();
+ 
+-        if(this.chunk == null || this.chunk.getChunkHolder() == null) {
+-            return new ArrayList<>();
+-        }
+-
+-        ChunkEntitySlices slices = this.chunk.getChunkHolder().getEntityChunk();
++        ChunkEntitySlices slices = getEntitySlices();
+         if (slices == null) {
+             return new ArrayList<>();
+         }
+@@ -194,6 +197,18 @@ public class NMSSlimeChunk implements SlimeChunk {
+         });
+     }
+ 
++    private ChunkEntitySlices getEntitySlices() {
++        if (this.entitySlices != null) {
++            return entitySlices;
++        }
++
++        if (this.chunk == null || this.chunk.getChunkHolder() == null) {
++            return null;
++        }
++
++        return this.chunk.getChunkHolder().getEntityChunk();
++    }
++
+     @Override
+     public CompoundTag getExtraData() {
+         return extra;
+diff --git a/src/main/java/com/infernalsuite/aswm/level/SlimeChunkLevel.java b/src/main/java/com/infernalsuite/aswm/level/SlimeChunkLevel.java
+index 2ebabf20c37d2b5c479de5bb241aa334f92a1104..866246838b6d6f23eacb1d9bad1c31cb2c1e76b0 100644
+--- a/src/main/java/com/infernalsuite/aswm/level/SlimeChunkLevel.java
++++ b/src/main/java/com/infernalsuite/aswm/level/SlimeChunkLevel.java
+@@ -19,12 +19,6 @@ public class SlimeChunkLevel extends LevelChunk {
+         this.inMemoryWorld = world.slimeInstance;
+     }
+ 
+-    @Override
+-    public void unloadCallback() {
+-        super.unloadCallback();
+-        this.inMemoryWorld.unload(this);
+-    }
+-
+     @Override
+     public void loadCallback() {
+         super.loadCallback();
+diff --git a/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java b/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java
+index 770679851baba2ddb9f8f427f4cd80ea8b32122b..619ccbab1a5582af1d1ad69fb0c54e52ca84847d 100644
+--- a/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java
++++ b/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java
+@@ -104,11 +104,11 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
+ 
+     // Authored by: Kenox <muranelp@gmail.com>
+     // Don't use the NMS live chunk in the chunk map
+-    public void unload(LevelChunk providedChunk) {
++    public void unload(LevelChunk providedChunk, ca.spottedleaf.moonrise.patches.chunk_system.level.entity.ChunkEntitySlices entitySlices) {
+         final int x = providedChunk.locX;
+         final int z = providedChunk.locZ;
+ 
+-        SlimeChunk chunk = new NMSSlimeChunk(providedChunk, getChunk(x, z));
++        SlimeChunk chunk = new NMSSlimeChunk(providedChunk, getChunk(x, z), entitySlices);
+ 
+         if (FastChunkPruner.canBePruned(this.liveWorld, providedChunk)) {
+             this.chunkStorage.remove(Util.chunkPosition(x, z));
+diff --git a/src/main/java/com/infernalsuite/aswm/level/SlimeLevelInstance.java b/src/main/java/com/infernalsuite/aswm/level/SlimeLevelInstance.java
+index acb6ea84fbc40a6907edb237b834feeb66075af8..2821d953e8b01cadf171508ac0b8e1eda6201970 100644
+--- a/src/main/java/com/infernalsuite/aswm/level/SlimeLevelInstance.java
++++ b/src/main/java/com/infernalsuite/aswm/level/SlimeLevelInstance.java
+@@ -202,9 +202,7 @@ public class SlimeLevelInstance extends ServerLevel {
+         propertyMap.setValue(SlimeProperties.SPAWN_YAW, angle);
+     }
+ 
+-    @Override
+-    public void unload(LevelChunk chunk) {
+-        this.slimeInstance.unload(chunk);
+-        super.unload(chunk);
++    public void onChunkUnloaded(LevelChunk chunk, ca.spottedleaf.moonrise.patches.chunk_system.level.entity.ChunkEntitySlices entityChunk) {
++        this.slimeInstance.unload(chunk, entityChunk);
+     }
+ }
+\ No newline at end of file

--- a/patches/server/0021-fix-pdc-not-saving-when-chunks-are-unloaded.patch
+++ b/patches/server/0021-fix-pdc-not-saving-when-chunks-are-unloaded.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: David Mayr <davidliebtkekse@gmail.com>
+Date: Thu, 5 Dec 2024 01:46:03 +0100
+Subject: [PATCH] fix pdc not saving when chunks are unloaded
+
+
+diff --git a/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java b/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java
+index 619ccbab1a5582af1d1ad69fb0c54e52ca84847d..8c71a932d49d55d861910712d3f482d39b62ad65 100644
+--- a/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java
++++ b/src/main/java/com/infernalsuite/aswm/level/SlimeInMemoryWorld.java
+@@ -114,6 +114,8 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
+             this.chunkStorage.remove(Util.chunkPosition(x, z));
+             return;
+         }
++        Tag<?> pdcTag = Converter.convertTag("ChunkBukkitValues", providedChunk.persistentDataContainer.toTagCompound());
++        chunk.getExtraData().getValue().put(pdcTag);
+ 
+         this.chunkStorage.put(Util.chunkPosition(x, z),
+                 new SlimeChunkSkeleton(chunk.getX(), chunk.getZ(), chunk.getSections(),


### PR DESCRIPTION
This PR has three separate changes that do the following:
- Update to paper commit da7138233f6392e791d790d1c3407414c855f9c2 (currently the newest 1.21.3)

- Resolve chunk & chunk entity saving by doing the following: 
The PR #133 attempted to fix the issues already, however it broke entity saving and didn't work for some people. My guess is that it didn't always work because the chunk was actually saved twice! (Once in SlimeChunkLevel in the unloadCallback and once in SlimeInMemoryWorld with the unload method) Both were fundamentally flawed. unloadCallback was issued too early in the unloading chain and broke chunks in specific scenarios when paired with the fast pruner, and the unload method was broken because it didn't save entities at all. How did I fix that? I added a custom hook in the second stage unload that included the entity slices that are normally not available anymore at this step to save them instead of the chunk holder entity slices. I don't like how I needed to pass it down to the SlimeNMSChunk in the unloading case, but it is what it is (please tell me if you like a different impl like a static helper for serializing chunks or a method that accepts slices in the NMS chunk or something else)

In my few tests I did yesterday, I did not encounter any issues (I could reproduce it pretty accurately before)

- Resolve Chunk PDC issues
When a chunk was unloaded, it didn't save the pdc before. It only saved it when the world got unloaded with active chunks. That's fixed in my third commit.

Please let me know if you want something changed or found a bug!