### PR TITLE
Add DynamoDbLoader for AWS DynamoDb backend support.

### DIFF
--- a/loaders/build.gradle.kts
+++ b/loaders/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     api("com.zaxxer:HikariCP:5.1.0")
     api("org.mongodb:mongodb-driver-sync:5.1.0")
     api("io.lettuce:lettuce-core:6.3.2.RELEASE")
+    api("software.amazon.awssdk:dynamodb-enhanced:2.30.18")
 
     compileOnly("io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT")
     compileOnly("commons-io:commons-io:2.11.0")

--- a/loaders/src/main/java/com/infernalsuite/aswm/loaders/dynamodb/DynamoDbLoader.java
+++ b/loaders/src/main/java/com/infernalsuite/aswm/loaders/dynamodb/DynamoDbLoader.java
@@ -1,0 +1,89 @@
+package com.infernalsuite.aswm.loaders.dynamodb;
+
+import com.infernalsuite.aswm.api.exceptions.UnknownWorldException;
+import com.infernalsuite.aswm.api.loaders.SlimeLoader;
+import com.infernalsuite.aswm.loaders.dynamodb.beans.WorldBean;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
+
+import java.io.IOException;
+import java.util.List;
+
+public class DynamoDbLoader implements SlimeLoader {
+    private final DynamoDbTable<WorldBean> worldTable;
+
+    public DynamoDbLoader(String worldTableName, String awsRegion, String awsAccessKeyId, String awsSecretAccessKey) {
+        DynamoDbClientBuilder dynamoDbClientBuilder = DynamoDbClient.builder().region(Region.of(awsRegion));
+        // If awsAccessKeyId and awsSecretAccessKey are empty, client uses default credentials (environment)
+        if (!awsAccessKeyId.isEmpty() || !awsSecretAccessKey.isEmpty()) {
+            AwsBasicCredentials awsBasicCredentials = AwsBasicCredentials.create(awsAccessKeyId, awsSecretAccessKey);
+            dynamoDbClientBuilder = dynamoDbClientBuilder.credentialsProvider(StaticCredentialsProvider.create(awsBasicCredentials));
+        }
+        DynamoDbEnhancedClient dynamoDbEnhancedClient = DynamoDbEnhancedClient.builder()
+                .dynamoDbClient(dynamoDbClientBuilder.build())
+                .build();
+        this.worldTable = dynamoDbEnhancedClient.table(worldTableName, TableSchema.fromBean(WorldBean.class));
+    }
+
+    @Override
+    public byte[] readWorld(String worldName) throws UnknownWorldException, IOException {
+        try {
+            WorldBean worldBean = worldTable.getItem(req -> req.key(key -> key.partitionValue(worldName)));
+            if (worldBean == null) {
+                throw new UnknownWorldException(worldName);
+            }
+            return worldBean.getData();
+        } catch (AwsServiceException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public boolean worldExists(String worldName) throws IOException {
+        try {
+            return worldTable.getItem(req -> req.key(key -> key.partitionValue(worldName))) == null;
+        } catch (AwsServiceException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public List<String> listWorlds() throws IOException {
+        try {
+            return worldTable.scan()
+                    .items()
+                    .stream()
+                    .map(WorldBean::getName)
+                    .toList();
+        } catch (AwsServiceException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public void saveWorld(String worldName, byte[] serializedWorld) throws IOException {
+        try {
+            worldTable.putItem(new WorldBean(serializedWorld, worldName));
+        } catch (AwsServiceException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public void deleteWorld(String worldName) throws UnknownWorldException, IOException {
+        try {
+            if (worldTable.deleteItem(req -> req.key(key -> key.partitionValue(worldName))) == null) {
+                throw new UnknownWorldException(worldName);
+            }
+        } catch (AwsServiceException e) {
+            throw new IOException(e);
+        }
+    }
+}

--- a/loaders/src/main/java/com/infernalsuite/aswm/loaders/dynamodb/beans/WorldBean.java
+++ b/loaders/src/main/java/com/infernalsuite/aswm/loaders/dynamodb/beans/WorldBean.java
@@ -1,0 +1,32 @@
+package com.infernalsuite.aswm.loaders.dynamodb.beans;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+
+@DynamoDbBean
+public class WorldBean {
+    private byte[] data;
+    private String name;
+
+    public WorldBean(byte[] data, String name) {
+        this.data = data;
+        this.name = name;
+    }
+
+    public byte[] getData() {
+        return data;
+    }
+
+    public void setData(byte[] data) {
+        this.data = data;
+    }
+
+    @DynamoDbPartitionKey
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/plugin/src/main/java/com/infernalsuite/aswm/plugin/config/DatasourcesConfig.java
+++ b/plugin/src/main/java/com/infernalsuite/aswm/plugin/config/DatasourcesConfig.java
@@ -17,6 +17,8 @@ public class DatasourcesConfig {
 
     @Setting("api")
     private APIConfig apiConfig = new APIConfig();
+    @Setting("dynamodb")
+    private DynamoDbConfig dynamoDbConfig = new DynamoDbConfig();
 
     @ConfigSerializable
     public static class MysqlConfig {
@@ -272,6 +274,36 @@ public class DatasourcesConfig {
         }
     }
 
+    @ConfigSerializable
+    public static class DynamoDbConfig {
+        @Setting("enabled")
+        private boolean enabled = false;
+        @Setting("tableName")
+        private String tableName = "slimeworldmanager";
+        @Setting("awsRegion")
+        private String awsRegion = "us-east-1";
+        @Setting("awsAccessKeyId")
+        private String awsAccessKeyId = "";
+        @Setting("awsSecretAccessKey")
+        private String awsSecretAccessKey = "";
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+        public String getTableName() {
+            return tableName;
+        }
+        public String getAwsRegion() {
+            return awsRegion;
+        }
+        public String getAwsAccessKeyId() {
+            return awsAccessKeyId;
+        }
+        public String getAwsSecretAccessKey() {
+            return awsSecretAccessKey;
+        }
+    }
+
     public FileConfig getFileConfig() {
         return fileConfig;
     }
@@ -306,6 +338,10 @@ public class DatasourcesConfig {
 
     public APIConfig getApiConfig() {
         return apiConfig;
+    }
+
+    public DynamoDbConfig getDynamoDbConfig() {
+        return dynamoDbConfig;
     }
 
     public void setApiConfig(APIConfig apiConfig) {

--- a/plugin/src/main/java/com/infernalsuite/aswm/plugin/loader/LoaderManager.java
+++ b/plugin/src/main/java/com/infernalsuite/aswm/plugin/loader/LoaderManager.java
@@ -1,5 +1,6 @@
 package com.infernalsuite.aswm.plugin.loader;
 
+import com.infernalsuite.aswm.loaders.dynamodb.DynamoDbLoader;
 import com.infernalsuite.aswm.plugin.config.ConfigManager;
 import com.infernalsuite.aswm.plugin.config.DatasourcesConfig;
 import com.infernalsuite.aswm.api.loaders.SlimeLoader;
@@ -84,6 +85,17 @@ public class LoaderManager {
                     apiConfig.getUsername(),
                     apiConfig.getToken(),
                     apiConfig.isIgnoreSslCertificate()
+            ));
+        }
+
+        // DynamoDbLoader
+        DatasourcesConfig.DynamoDbConfig dynamoDbConfig = config.getDynamoDbConfig();
+        if (dynamoDbConfig.isEnabled()) {
+            registerLoader("dynamodb", new DynamoDbLoader(
+                    dynamoDbConfig.getTableName(),
+                    dynamoDbConfig.getAwsRegion(),
+                    dynamoDbConfig.getAwsAccessKeyId(),
+                    dynamoDbConfig.getAwsSecretAccessKey()
             ));
         }
     }


### PR DESCRIPTION
- Added DynamoDbLoader implementing SlimeLoader providing backend support
- Added DatasourcesConfig.DynamoDbConfig providing plugin configuration options for table name, region, and AWS credentials
- Added overhead and orchestration to load the DynamoDbLoader

AWS IAM Policy granting required permissions to use the DynamoDbLoader:
```json
{
    "Version": "2012-10-17",
    "Statement": {
        "Effect": "Allow",
        "Action":[
            "dynamodb:DeleteItem",
            "dynamodb:GetItem",
            "dynamodb:Scan"
        ],
        "Resource": ["arn:aws:dynamodb:{AWS Region}:{AWS Account ID}:table/${Table Name}"]
    }
}
```

Requires an existing AWS DynamoDB table or global table with compatible primary key labeled "name".