### PR TITLE
Promote 1.21.5 to develop 

### DIFF
--- a/aspaper-api/build.gradle.kts.patch
+++ b/aspaper-api/build.gradle.kts.patch
@@ -13,15 +13,15 @@
      testRuntimeOnly("org.junit.platform:junit-platform-launcher")
  }
  
--val generatedApiPath: java.nio.file.Path = layout.projectDirectory.dir("src/generated/java").asFile.toPath()
-+val generatedApiPath: java.nio.file.Path = rootProject.layout.projectDirectory.dir("paper-api/src/generated/java").asFile.toPath()
+-val generatedDir: java.nio.file.Path = layout.projectDirectory.dir("src/generated/java").asFile.toPath()
++val generatedDir: java.nio.file.Path = rootProject.layout.projectDirectory.dir("paper-api/src/generated/java").asFile.toPath()
  idea {
      module {
-         generatedSourceDirs.add(generatedApiPath.toFile())
+         generatedSourceDirs.add(generatedDir.toFile())
 @@ -103,6 +_,18 @@
      main {
          java {
-             srcDir(generatedApiPath)
+             srcDir(generatedDir)
 +            srcDir(file("../paper-api/src/main/java"))
 +        }
 +        resources {

--- a/aspaper-api/build.gradle.kts.patch
+++ b/aspaper-api/build.gradle.kts.patch
@@ -1,10 +1,9 @@
 --- a/paper-api/build.gradle.kts
 +++ b/paper-api/build.gradle.kts
-@@ -39,7 +_,7 @@
+@@ -41,6 +_,7 @@
  }
  
  dependencies {
--
 +    api(project(":api")) //ASP
      // api dependencies are listed transitively to API consumers
      api("com.google.guava:guava:33.3.1-jre")

--- a/aspaper-server/build.gradle.kts.patch
+++ b/aspaper-server/build.gradle.kts.patch
@@ -1,8 +1,8 @@
 --- a/paper-server/build.gradle.kts
 +++ b/paper-server/build.gradle.kts
-@@ -21,6 +_,17 @@
-     // macheOldPath = file("F:\\Projects\\PaperTooling\\mache\\versions\\1.21.4\\src\\main\\java")
-     // gitFilePatches = true
+@@ -28,6 +_,17 @@
+     //    oldPaperCommit = "f4f275519f7c1fbe9db173b7144a4fe81440e365"
+     //}
  
 +    val aspaper = forks.register("aspaper") {
 +        upstream.patchDir("paperServer") {
@@ -16,9 +16,9 @@
 +    activeFork = aspaper
 +
      spigot {
-         buildDataRef = "3edaf46ec1eed4115ce1b18d2846cded42577e42"
-         packageVersion = "v1_21_R3" // also needs to be updated in MappingEnvironment
-@@ -101,7 +_,20 @@
+         buildDataRef = "702e1a0a5072b2c4082371d5228cb30525687efc"
+         packageVersion = "v1_21_R4" // also needs to be updated in MappingEnvironment
+@@ -108,7 +_,20 @@
      }
  }
  
@@ -40,18 +40,17 @@
  configurations.named(log4jPlugins.compileClasspathConfigurationName) {
      extendsFrom(configurations.compileClasspath.get())
  }
-@@ -119,7 +_,9 @@
+@@ -130,7 +_,8 @@
  }
  
  dependencies {
 -    implementation(project(":paper-api"))
 +    implementation(project(":aspaper-api")) //ASP
 +    implementation(project(":core")) //ASP
-+    implementation("commons-io:commons-io:2.11.0")
      implementation("ca.spottedleaf:concurrentutil:0.0.3")
      implementation("org.jline:jline-terminal-ffm:3.27.1") // use ffm on java 22+
      implementation("org.jline:jline-terminal-jni:3.27.1") // fall back to jni on java 21
-@@ -189,14 +_,14 @@
+@@ -201,14 +_,14 @@
          val gitBranch = git.exec(providers, "rev-parse", "--abbrev-ref", "HEAD").get().trim()
          attributes(
              "Main-Class" to "org.bukkit.craftbukkit.Main",
@@ -71,3 +70,12 @@
              "Build-Number" to (build ?: ""),
              "Build-Time" to buildTime.toString(),
              "Git-Branch" to gitBranch,
+@@ -262,7 +_,7 @@
+     jvmArgumentProviders.add(provider)
+ }
+ 
+-val generatedDir: java.nio.file.Path = layout.projectDirectory.dir("src/generated/java").asFile.toPath()
++val generatedDir: java.nio.file.Path = rootProject.layout.projectDirectory.dir("paper-server/src/generated/java").asFile.toPath()
+ idea {
+     module {
+         generatedSourceDirs.add(generatedDir.toFile())

--- a/aspaper-server/build.gradle.kts.patch
+++ b/aspaper-server/build.gradle.kts.patch
@@ -50,7 +50,7 @@
      implementation("ca.spottedleaf:concurrentutil:0.0.3")
      implementation("org.jline:jline-terminal-ffm:3.27.1") // use ffm on java 22+
      implementation("org.jline:jline-terminal-jni:3.27.1") // fall back to jni on java 21
-@@ -201,14 +_,14 @@
+@@ -206,14 +_,14 @@
          val gitBranch = git.exec(providers, "rev-parse", "--abbrev-ref", "HEAD").get().trim()
          attributes(
              "Main-Class" to "org.bukkit.craftbukkit.Main",
@@ -70,7 +70,7 @@
              "Build-Number" to (build ?: ""),
              "Build-Time" to buildTime.toString(),
              "Git-Branch" to gitBranch,
-@@ -262,7 +_,7 @@
+@@ -267,7 +_,7 @@
      jvmArgumentProviders.add(provider)
  }
  

--- a/aspaper-server/minecraft-patches/features/0001-Disable-dragon-battle.patch
+++ b/aspaper-server/minecraft-patches/features/0001-Disable-dragon-battle.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Disable dragon battle
 
 
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index c5ddf6c0f0ff795da2f7aec8915a081b334423ec..a373f5b8e03f4179a4d9f63d79abc19a38f952b6 100644
+index af678738023b3ee4c9333a3b92817decc60f95fd..c156efe43a04490cdf7f0870179c0aa06902b96a 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -689,7 +689,13 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -680,7 +680,13 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
          );
          this.structureManager = new StructureManager(this, this.serverLevelData.worldGenOptions(), this.structureCheck); // CraftBukkit
          if (this.dimension() == Level.END && this.dimensionTypeRegistration().is(BuiltinDimensionTypes.END) || env == org.bukkit.World.Environment.THE_END) { // CraftBukkit - Allow to create EnderDragonBattle in default and custom END

--- a/aspaper-server/minecraft-patches/features/0001-Disable-dragon-battle.patch
+++ b/aspaper-server/minecraft-patches/features/0001-Disable-dragon-battle.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Disable dragon battle
 
 
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index af678738023b3ee4c9333a3b92817decc60f95fd..c156efe43a04490cdf7f0870179c0aa06902b96a 100644
+index f8c2eec34c4639a5daaefa0962c44d40b7f22f93..a32a4756ac0c0261b3f28de7e10130d03c5780ce 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -680,7 +680,13 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -681,7 +681,13 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
          );
          this.structureManager = new StructureManager(this, this.serverLevelData.worldGenOptions(), this.structureCheck); // CraftBukkit
          if (this.dimension() == Level.END && this.dimensionTypeRegistration().is(BuiltinDimensionTypes.END) || env == org.bukkit.World.Environment.THE_END) { // CraftBukkit - Allow to create EnderDragonBattle in default and custom END

--- a/aspaper-server/minecraft-patches/features/0002-World-overrides.patch
+++ b/aspaper-server/minecraft-patches/features/0002-World-overrides.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] World overrides
 
 
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 1509c96ae9247d1d5ddd0fc50210f88da10bf3de..bbc4be3c3811ee19bd791cb6626474038d35a298 100644
+index 9623b1124c43d6aca94588a4153475e647751788..912da569c851dd6d3747ac19dbfff27c416ca981 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -516,18 +516,33 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -514,18 +514,33 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              if (levelStemKey == LevelStem.NETHER) {
                  if (this.server.getAllowNether()) {
                      dimension = -1;

--- a/aspaper-server/minecraft-patches/features/0003-Avoid-IO-call-for-UUID.patch
+++ b/aspaper-server/minecraft-patches/features/0003-Avoid-IO-call-for-UUID.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Avoid IO call for UUID
 
 
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index c156efe43a04490cdf7f0870179c0aa06902b96a..16493872aa3a4384c180b1de4dff4617ad5978da 100644
+index a32a4756ac0c0261b3f28de7e10130d03c5780ce..a13ebfbff00340c7ab500e20702120cbae9d3fb3 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -608,7 +608,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -609,7 +609,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
          super(serverLevelData, dimension, server.registryAccess(), levelStem.type(), false, isDebug, biomeZoomSeed, server.getMaxChainedNeighborUpdates(), gen, biomeProvider, env, spigotConfig -> server.paperConfigurations.createWorldConfig(io.papermc.paper.configuration.PaperConfigurations.createWorldContextMap(levelStorageAccess.levelDirectory.path(), serverLevelData.getLevelName(), dimension.location(), spigotConfig, server.registryAccess(), serverLevelData.getGameRules())), dispatcher); // Paper - create paper world configs; Async-Anti-Xray: Pass executor
          this.pvpMode = server.isPvpAllowed();
          this.levelStorageAccess = levelStorageAccess;

--- a/aspaper-server/minecraft-patches/features/0003-Avoid-IO-call-for-UUID.patch
+++ b/aspaper-server/minecraft-patches/features/0003-Avoid-IO-call-for-UUID.patch
@@ -5,15 +5,15 @@ Subject: [PATCH] Avoid IO call for UUID
 
 
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 8429a97047f4321df96fd11559867bce74d0a49c..60608cea4e564c1ce47f8a4de2c1a48986bbdecb 100644
+index c156efe43a04490cdf7f0870179c0aa06902b96a..16493872aa3a4384c180b1de4dff4617ad5978da 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -617,7 +617,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -608,7 +608,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
          super(serverLevelData, dimension, server.registryAccess(), levelStem.type(), false, isDebug, biomeZoomSeed, server.getMaxChainedNeighborUpdates(), gen, biomeProvider, env, spigotConfig -> server.paperConfigurations.createWorldConfig(io.papermc.paper.configuration.PaperConfigurations.createWorldContextMap(levelStorageAccess.levelDirectory.path(), serverLevelData.getLevelName(), dimension.location(), spigotConfig, server.registryAccess(), serverLevelData.getGameRules())), dispatcher); // Paper - create paper world configs; Async-Anti-Xray: Pass executor
          this.pvpMode = server.isPvpAllowed();
          this.levelStorageAccess = levelStorageAccess;
--        this.uuid = org.bukkit.craftbukkit.util.WorldUUID.getUUID(levelStorageAccess.levelDirectory.path().toFile());
-+        this.uuid = bootstrap == null ? org.bukkit.craftbukkit.util.WorldUUID.getUUID(levelStorageAccess.levelDirectory.path().toFile()) : UUID.randomUUID(); //ASP - avoid IO calls
+-        this.uuid = org.bukkit.craftbukkit.util.WorldUUID.getOrCreate(levelStorageAccess.levelDirectory.path().toFile());
++        this.uuid = bootstrap == null ? org.bukkit.craftbukkit.util.WorldUUID.getOrCreate(levelStorageAccess.levelDirectory.path().toFile()) : java.util.UUID.randomUUID(); //ASP - avoid IO calls
          // CraftBukkit end
          this.tickTime = tickTime;
          this.server = server;

--- a/aspaper-server/minecraft-patches/features/0004-Prevent-config-disk-io-on-world-load.patch
+++ b/aspaper-server/minecraft-patches/features/0004-Prevent-config-disk-io-on-world-load.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent config disk io on world load
 
 
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 16493872aa3a4384c180b1de4dff4617ad5978da..5c89b8cda6383d7feb5b83fd7c805af819a17f8b 100644
+index a13ebfbff00340c7ab500e20702120cbae9d3fb3..5b7bb4bfe47a1c4fb2d3e52b03eb23c50c85627d 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -605,7 +605,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -606,7 +606,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
      ) {
          //ASP end
          // CraftBukkit start
@@ -18,10 +18,10 @@ index 16493872aa3a4384c180b1de4dff4617ad5978da..5c89b8cda6383d7feb5b83fd7c805af8
          this.levelStorageAccess = levelStorageAccess;
          this.uuid = bootstrap == null ? org.bukkit.craftbukkit.util.WorldUUID.getOrCreate(levelStorageAccess.levelDirectory.path().toFile()) : java.util.UUID.randomUUID(); //ASP - avoid IO calls
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index 3a254bc46e320364d660c48d67d6db86c72acf94..7ff98d209298da2e57fe03bddfb3f18fa619b25f 100644
+index 013ed7dbe2309f562f63e66203179a90566e8115..f2de12320d1435ec65e0feac64fb6e88ff3ef811 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
-@@ -837,7 +837,7 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
+@@ -838,7 +838,7 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
          this.maxSectionY = this.maxY >> 4;
          this.sectionsCount = this.maxSectionY - this.minSectionY + 1;
          // Paper end - getblock optimisations - cache world height/sections

--- a/aspaper-server/minecraft-patches/features/0004-Prevent-config-disk-io-on-world-load.patch
+++ b/aspaper-server/minecraft-patches/features/0004-Prevent-config-disk-io-on-world-load.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent config disk io on world load
 
 
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 60608cea4e564c1ce47f8a4de2c1a48986bbdecb..1b5d65136421b63353b1c6cd8ae5d413ec070b92 100644
+index 16493872aa3a4384c180b1de4dff4617ad5978da..5c89b8cda6383d7feb5b83fd7c805af819a17f8b 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -614,7 +614,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -605,7 +605,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
      ) {
          //ASP end
          // CraftBukkit start
@@ -16,12 +16,12 @@ index 60608cea4e564c1ce47f8a4de2c1a48986bbdecb..1b5d65136421b63353b1c6cd8ae5d413
 +        super(serverLevelData, dimension, server.registryAccess(), levelStem.type(), false, isDebug, biomeZoomSeed, server.getMaxChainedNeighborUpdates(), gen, biomeProvider, env, spigotConfig -> bootstrap != null ? com.infernalsuite.asp.config.SlimePaperWorldConfig.initializeOrGet() : server.paperConfigurations.createWorldConfig(io.papermc.paper.configuration.PaperConfigurations.createWorldContextMap(levelStorageAccess.levelDirectory.path(), serverLevelData.getLevelName(), dimension.location(), spigotConfig, server.registryAccess(), serverLevelData.getGameRules())), dispatcher); // Paper - create paper world configs; Async-Anti-Xray: Pass executor //ASP - Optimize world config
          this.pvpMode = server.isPvpAllowed();
          this.levelStorageAccess = levelStorageAccess;
-         this.uuid = bootstrap == null ? org.bukkit.craftbukkit.util.WorldUUID.getUUID(levelStorageAccess.levelDirectory.path().toFile()) : UUID.randomUUID(); //ASP - avoid IO calls
+         this.uuid = bootstrap == null ? org.bukkit.craftbukkit.util.WorldUUID.getOrCreate(levelStorageAccess.levelDirectory.path().toFile()) : java.util.UUID.randomUUID(); //ASP - avoid IO calls
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
-index 1dbe7c7c1051c3972105534a07ce50d4cf98fc85..e1d3c292b9efccb032245f4f1618f2650f0bc619 100644
+index 3a254bc46e320364d660c48d67d6db86c72acf94..7ff98d209298da2e57fe03bddfb3f18fa619b25f 100644
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
-@@ -851,7 +851,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable, ca.spottedl
+@@ -837,7 +837,7 @@ public abstract class Level implements LevelAccessor, UUIDLookup<Entity>, AutoCl
          this.maxSectionY = this.maxY >> 4;
          this.sectionsCount = this.maxSectionY - this.minSectionY + 1;
          // Paper end - getblock optimisations - cache world height/sections

--- a/aspaper-server/minecraft-patches/features/0005-Read-only-dimension-data-store.patch
+++ b/aspaper-server/minecraft-patches/features/0005-Read-only-dimension-data-store.patch
@@ -5,21 +5,21 @@ Subject: [PATCH] Read only dimension data store
 
 
 diff --git a/net/minecraft/server/level/ServerChunkCache.java b/net/minecraft/server/level/ServerChunkCache.java
-index 6540b2d6a1062d883811ce240c49d30d1925b291..f89eb4e909c2eeb22732dcb368b3758637f036f7 100644
+index 5d63bf024cbcbd2f627c64fee77553c9a512bd15..da169d319e9c09de2d5a34784af4e4c133b10f46 100644
 --- a/net/minecraft/server/level/ServerChunkCache.java
 +++ b/net/minecraft/server/level/ServerChunkCache.java
-@@ -207,7 +207,13 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
+@@ -210,7 +210,13 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
              LOGGER.error("Failed to create dimension data storage directory", (Throwable)var15);
          }
  
--        this.dataStorage = new DimensionDataStorage(path, fixerUpper, level.registryAccess());
+-        this.dataStorage = new DimensionDataStorage(new SavedData.Context(level), path, fixerUpper, level.registryAccess());
 +        //ASP start - No dimension data storage
 +        if(level instanceof com.infernalsuite.asp.level.SlimeLevelInstance) {
-+            this.dataStorage = new com.infernalsuite.asp.level.ReadOnlyDimensionDataStorage(path, fixerUpper, level.registryAccess());
++            this.dataStorage = new com.infernalsuite.asp.level.ReadOnlyDimensionDataStorage(new SavedData.Context(level), path, fixerUpper, level.registryAccess());
 +        } else {
-+            this.dataStorage = new DimensionDataStorage(path, fixerUpper, level.registryAccess());
++            this.dataStorage = new DimensionDataStorage(new SavedData.Context(level), path, fixerUpper, level.registryAccess());
 +        }
 +        //ASP end - No dimension data storage
+         this.ticketStorage = this.dataStorage.computeIfAbsent(TicketStorage.TYPE);
          this.chunkMap = new ChunkMap(
              level,
-             levelStorageAccess,

--- a/aspaper-server/minecraft-patches/sources/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/ChunkHolderManager.java.patch
+++ b/aspaper-server/minecraft-patches/sources/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/ChunkHolderManager.java.patch
@@ -1,6 +1,6 @@
 --- a/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/ChunkHolderManager.java
 +++ b/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/ChunkHolderManager.java
-@@ -184,7 +_,9 @@
+@@ -186,7 +_,9 @@
          };
      }
  

--- a/aspaper-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/aspaper-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -561,7 +_,32 @@
+@@ -562,7 +_,32 @@
      }
      // Paper end - chunk tick iteration
  
@@ -34,7 +34,7 @@
          MinecraftServer server,
          Executor dispatcher,
          LevelStorageSource.LevelStorageAccess levelStorageAccess,
-@@ -578,6 +_,7 @@
+@@ -579,6 +_,7 @@
          org.bukkit.generator.ChunkGenerator gen, // CraftBukkit
          org.bukkit.generator.BiomeProvider biomeProvider // CraftBukkit
      ) {
@@ -42,7 +42,7 @@
          // CraftBukkit start
          super(serverLevelData, dimension, server.registryAccess(), levelStem.type(), false, isDebug, biomeZoomSeed, server.getMaxChainedNeighborUpdates(), gen, biomeProvider, env, spigotConfig -> server.paperConfigurations.createWorldConfig(io.papermc.paper.configuration.PaperConfigurations.createWorldContextMap(levelStorageAccess.levelDirectory.path(), serverLevelData.getLevelName(), dimension.location(), spigotConfig, server.registryAccess(), serverLevelData.getGameRules())), dispatcher); // Paper - create paper world configs; Async-Anti-Xray: Pass executor
          this.pvpMode = server.isPvpAllowed();
-@@ -605,6 +_,13 @@
+@@ -606,6 +_,13 @@
              chunkGenerator = new org.bukkit.craftbukkit.generator.CustomChunkGenerator(this, chunkGenerator, gen);
          }
          // CraftBukkit end
@@ -56,7 +56,7 @@
          boolean flag = server.forceSynchronousWrites();
          DataFixer fixerUpper = server.getFixerUpper();
          // Paper - rewrite chunk system
-@@ -684,6 +_,12 @@
+@@ -685,6 +_,12 @@
      public void setDragonFight(@Nullable EndDragonFight dragonFight) {
          this.dragonFight = dragonFight;
      }

--- a/aspaper-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/aspaper-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
-@@ -570,7 +_,32 @@
+@@ -561,7 +_,32 @@
      }
      // Paper end - chunk tick iteration
  
@@ -34,7 +34,7 @@
          MinecraftServer server,
          Executor dispatcher,
          LevelStorageSource.LevelStorageAccess levelStorageAccess,
-@@ -587,6 +_,7 @@
+@@ -578,6 +_,7 @@
          org.bukkit.generator.ChunkGenerator gen, // CraftBukkit
          org.bukkit.generator.BiomeProvider biomeProvider // CraftBukkit
      ) {
@@ -42,7 +42,7 @@
          // CraftBukkit start
          super(serverLevelData, dimension, server.registryAccess(), levelStem.type(), false, isDebug, biomeZoomSeed, server.getMaxChainedNeighborUpdates(), gen, biomeProvider, env, spigotConfig -> server.paperConfigurations.createWorldConfig(io.papermc.paper.configuration.PaperConfigurations.createWorldContextMap(levelStorageAccess.levelDirectory.path(), serverLevelData.getLevelName(), dimension.location(), spigotConfig, server.registryAccess(), serverLevelData.getGameRules())), dispatcher); // Paper - create paper world configs; Async-Anti-Xray: Pass executor
          this.pvpMode = server.isPvpAllowed();
-@@ -614,6 +_,13 @@
+@@ -605,6 +_,13 @@
              chunkGenerator = new org.bukkit.craftbukkit.generator.CustomChunkGenerator(this, chunkGenerator, gen);
          }
          // CraftBukkit end
@@ -56,7 +56,7 @@
          boolean flag = server.forceSynchronousWrites();
          DataFixer fixerUpper = server.getFixerUpper();
          // Paper - rewrite chunk system
-@@ -695,6 +_,12 @@
+@@ -684,6 +_,12 @@
      public void setDragonFight(@Nullable EndDragonFight dragonFight) {
          this.dragonFight = dragonFight;
      }

--- a/aspaper-server/minecraft-patches/sources/net/minecraft/world/level/chunk/storage/SerializableChunkData.java.patch
+++ b/aspaper-server/minecraft-patches/sources/net/minecraft/world/level/chunk/storage/SerializableChunkData.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/chunk/storage/SerializableChunkData.java
 +++ b/net/minecraft/world/level/chunk/storage/SerializableChunkData.java
-@@ -350,6 +_,12 @@
+@@ -361,6 +_,12 @@
                  if (flag2) {
                      lightEngine.queueSectionData(LightLayer.SKY, sectionPos, sectionData.skyLight);
                  }

--- a/aspaper-server/minecraft-patches/sources/net/minecraft/world/level/chunk/storage/SerializableChunkData.java.patch
+++ b/aspaper-server/minecraft-patches/sources/net/minecraft/world/level/chunk/storage/SerializableChunkData.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/chunk/storage/SerializableChunkData.java
 +++ b/net/minecraft/world/level/chunk/storage/SerializableChunkData.java
-@@ -387,6 +_,12 @@
+@@ -350,6 +_,12 @@
                  if (flag2) {
                      lightEngine.queueSectionData(LightLayer.SKY, sectionPos, sectionData.skyLight);
                  }

--- a/aspaper-server/paper-patches/features/0004-Delete-temp-folder-after-world-is-unloaded.patch
+++ b/aspaper-server/paper-patches/features/0004-Delete-temp-folder-after-world-is-unloaded.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Delete temp folder after world is unloaded
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 090b295ccd7f61c2f1cc5131ffb0371c22e48f04..0bbc51dcf0ba7773b818994890d14fd0300608f3 100644
+index 96d60c6649d40537e8e3a87774300a751efc0c61..04c21c5760f1db9011e431702700caec97fb1a93 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1518,6 +1518,12 @@ public final class CraftServer implements Server {
+@@ -1476,6 +1476,12 @@ public final class CraftServer implements Server {
              handle.getChunkSource().close(save);
              io.papermc.paper.FeatureHooks.closeEntityManager(handle, save); // SPIGOT-6722: close entityManager // Paper - chunk system
              handle.levelStorageAccess.close();

--- a/aspaper-server/paper-patches/features/0005-Prevent-config-disk-io-on-world-load.patch
+++ b/aspaper-server/paper-patches/features/0005-Prevent-config-disk-io-on-world-load.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent config disk io on world load
 
 
 diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
-index 7c585b71d06f438f414227c2625f27b6c323045e..ea4cd0bb12e0a04c6d738aca8dbb206f192244a3 100644
+index c935d75b83338ce41507e9be11153dd1c4052cb6..3feaba566c22b1e93b2b4edc7786723a2f9e28c6 100644
 --- a/src/main/java/org/spigotmc/SpigotConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotConfig.java
-@@ -78,7 +78,12 @@ public class SpigotConfig {
+@@ -79,7 +79,12 @@ public class SpigotConfig {
          }
      }
  
@@ -21,7 +21,7 @@ index 7c585b71d06f438f414227c2625f27b6c323045e..ea4cd0bb12e0a04c6d738aca8dbb206f
          for (Method method : clazz.getDeclaredMethods()) {
              if (Modifier.isPrivate(method.getModifiers())) {
                  if (method.getParameterTypes().length == 0 && method.getReturnType() == Void.TYPE) {
-@@ -95,7 +100,11 @@ public class SpigotConfig {
+@@ -96,7 +101,11 @@ public class SpigotConfig {
          }
  
          try {

--- a/aspaper-server/paper-patches/features/0005-Prevent-config-disk-io-on-world-load.patch
+++ b/aspaper-server/paper-patches/features/0005-Prevent-config-disk-io-on-world-load.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Prevent config disk io on world load
 
 
 diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
-index e0d4222a99f22d7130d95cf29b034a98f2f3b76e..776440ec20c7bf0acac8678773b0a5d29548c270 100644
+index 7c585b71d06f438f414227c2625f27b6c323045e..ea4cd0bb12e0a04c6d738aca8dbb206f192244a3 100644
 --- a/src/main/java/org/spigotmc/SpigotConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotConfig.java
 @@ -78,7 +78,12 @@ public class SpigotConfig {
@@ -13,7 +13,7 @@ index e0d4222a99f22d7130d95cf29b034a98f2f3b76e..776440ec20c7bf0acac8678773b0a5d2
      }
  
 +    // ASP start - Improve Slime IO
-     public static void readConfig(Class<?> clazz, Object instance) { // Paper - package-private -> public
+     public static void readConfig(Class<?> clazz, Object instance) {
 +        readConfig(clazz, instance, true);
 +    }
 +    public static void readConfig(Class<?> clazz, Object instance, boolean save) {
@@ -35,7 +35,7 @@ index e0d4222a99f22d7130d95cf29b034a98f2f3b76e..776440ec20c7bf0acac8678773b0a5d2
              Bukkit.getLogger().log(Level.SEVERE, "Could not save " + SpigotConfig.CONFIG_FILE, ex);
          }
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-index 89e2adbc1e1a0709d03e151e3ffcdbff10a44098..6b2241efbc248324f178a547aea9f398ed624247 100644
+index 43c6240ec2855c0f668ce04de29d22a223d2612f..c6f398977149c8b35454fb79f099322c36d557d5 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
 @@ -10,17 +10,28 @@ public class SpigotWorldConfig {

--- a/aspaper-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/CraftServer.java.patch
+++ b/aspaper-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/CraftServer.java.patch
@@ -1,6 +1,6 @@
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1508,6 +_,8 @@
+@@ -1466,6 +_,8 @@
              return false;
          }
  

--- a/aspaper-server/src/main/java/com/infernalsuite/asp/Converter.java
+++ b/aspaper-server/src/main/java/com/infernalsuite/asp/Converter.java
@@ -99,14 +99,14 @@ public class Converter {
     public static <T extends BinaryTag> T convertTag(Tag base) {
         return switch (base.getId()) {
             case Tag.TAG_END -> (T) EndBinaryTag.endBinaryTag();
-            case Tag.TAG_BYTE -> (T) ByteBinaryTag.byteBinaryTag(((ByteTag) base).getAsByte());
-            case Tag.TAG_SHORT -> (T) ShortBinaryTag.shortBinaryTag(((ShortTag) base).getAsShort());
-            case Tag.TAG_INT -> (T) IntBinaryTag.intBinaryTag(((IntTag) base).getAsInt());
-            case Tag.TAG_LONG -> (T) LongBinaryTag.longBinaryTag(((LongTag) base).getAsLong());
-            case Tag.TAG_FLOAT -> (T) FloatBinaryTag.floatBinaryTag(((FloatTag) base).getAsFloat());
-            case Tag.TAG_DOUBLE -> (T) DoubleBinaryTag.doubleBinaryTag(((DoubleTag) base).getAsDouble());
+            case Tag.TAG_BYTE -> (T) ByteBinaryTag.byteBinaryTag(((ByteTag) base).byteValue());
+            case Tag.TAG_SHORT -> (T) ShortBinaryTag.shortBinaryTag(((ShortTag) base).shortValue());
+            case Tag.TAG_INT -> (T) IntBinaryTag.intBinaryTag(((IntTag) base).intValue());
+            case Tag.TAG_LONG -> (T) LongBinaryTag.longBinaryTag(((LongTag) base).longValue());
+            case Tag.TAG_FLOAT -> (T) FloatBinaryTag.floatBinaryTag(((FloatTag) base).floatValue());
+            case Tag.TAG_DOUBLE -> (T) DoubleBinaryTag.doubleBinaryTag(((DoubleTag) base).doubleValue());
             case Tag.TAG_BYTE_ARRAY -> (T) ByteArrayBinaryTag.byteArrayBinaryTag(((ByteArrayTag) base).getAsByteArray());
-            case Tag.TAG_STRING -> (T) StringBinaryTag.stringBinaryTag(((StringTag) base).getAsString());
+            case Tag.TAG_STRING -> (T) StringBinaryTag.stringBinaryTag(((StringTag) base).asString().orElseThrow()); //TODO(david): Figure out what to do with optional?
             case Tag.TAG_LIST -> {
                 ListTag originalList = ((ListTag) base);
                 if(originalList.isEmpty()) {
@@ -119,7 +119,7 @@ public class Converter {
             case Tag.TAG_COMPOUND -> {
                 CompoundBinaryTag.Builder builder = CompoundBinaryTag.builder();
                 CompoundTag originalCompound = ((CompoundTag) base);
-                for (String key : originalCompound.getAllKeys()) builder.put(key, convertTag(Objects.requireNonNull(originalCompound.get(key))));
+                for (String key : originalCompound.keySet()) builder.put(key, convertTag(Objects.requireNonNull(originalCompound.get(key))));
                 yield (T) builder.build();
             }
             case Tag.TAG_INT_ARRAY -> (T) IntArrayBinaryTag.intArrayBinaryTag(((IntArrayTag) base).getAsIntArray());

--- a/aspaper-server/src/main/java/com/infernalsuite/asp/SimpleDataFixerConverter.java
+++ b/aspaper-server/src/main/java/com/infernalsuite/asp/SimpleDataFixerConverter.java
@@ -24,15 +24,24 @@ class SimpleDataFixerConverter implements SlimeWorldReader<SlimeWorld> {
 
     @Override
     public SlimeWorld readFromData(SlimeWorld data) {
-        return data; //TODO(david): re-add this as soon as dataconverter is back in paper
-        /* int newVersion = SharedConstants.getCurrentVersion().getDataVersion().getVersion(); 1.21.5
+        int newVersion = SharedConstants.getCurrentVersion().getDataVersion().getVersion();
         int currentVersion = data.getDataVersion();
         // Already fixed
         if (currentVersion == newVersion) {
             return data;
         }
 
-        long encodedNewVersion = DataConverter.encodeVersions(newVersion, Integer.MAX_VALUE);
+        System.out.println("""
+                You tried loading a world from a previous minecraft version with the dev build of 1.21.5
+                This is currently unsupported until paper reintroduces the dataconverter.
+                This functionality will come back in a future release.
+                
+                Also: Please don't bug the paper team to re-add dataconverter. As of 02.04.2025, paper 1.21.5 isn't even released.
+                Give them time. Thank you.
+                """);
+        throw new IllegalStateException("Loading old worlds is temporarily unsupported.");
+        //TODO(david): re-add this as soon as dataconverter is back in paper
+        /*long encodedNewVersion = DataConverter.encodeVersions(newVersion, Integer.MAX_VALUE); 1.21.5
         long encodedCurrentVersion = DataConverter.encodeVersions(currentVersion, Integer.MAX_VALUE);
 
         Long2ObjectMap<SlimeChunk> chunks = new Long2ObjectOpenHashMap<>();

--- a/aspaper-server/src/main/java/com/infernalsuite/asp/SimpleDataFixerConverter.java
+++ b/aspaper-server/src/main/java/com/infernalsuite/asp/SimpleDataFixerConverter.java
@@ -1,9 +1,9 @@
 package com.infernalsuite.asp;
 
-import ca.spottedleaf.dataconverter.converters.DataConverter;
+/*import ca.spottedleaf.dataconverter.converters.DataConverter;
 import ca.spottedleaf.dataconverter.minecraft.datatypes.MCTypeRegistry;
 import ca.spottedleaf.dataconverter.minecraft.walkers.generic.WalkerUtils;
-import ca.spottedleaf.dataconverter.types.nbt.NBTMapType;
+import ca.spottedleaf.dataconverter.types.nbt.NBTMapType; 1.21.5 */
 import com.infernalsuite.asp.serialization.SlimeWorldReader;
 import com.infernalsuite.asp.skeleton.SkeletonSlimeWorld;
 import com.infernalsuite.asp.skeleton.SlimeChunkSectionSkeleton;
@@ -24,7 +24,8 @@ class SimpleDataFixerConverter implements SlimeWorldReader<SlimeWorld> {
 
     @Override
     public SlimeWorld readFromData(SlimeWorld data) {
-        int newVersion = SharedConstants.getCurrentVersion().getDataVersion().getVersion();
+        return data; //TODO(david): re-add this as soon as dataconverter is back in paper
+        /* int newVersion = SharedConstants.getCurrentVersion().getDataVersion().getVersion(); 1.21.5
         int currentVersion = data.getDataVersion();
         // Already fixed
         if (currentVersion == newVersion) {
@@ -92,7 +93,7 @@ class SimpleDataFixerConverter implements SlimeWorldReader<SlimeWorld> {
                 data.getExtraData(),
                 data.getPropertyMap(),
                 newVersion
-        );
+        ); */
     }
 
 

--- a/aspaper-server/src/main/java/com/infernalsuite/asp/SlimeNMSBridgeImpl.java
+++ b/aspaper-server/src/main/java/com/infernalsuite/asp/SlimeNMSBridgeImpl.java
@@ -1,8 +1,5 @@
 package com.infernalsuite.asp;
 
-import ca.spottedleaf.dataconverter.converters.DataConverter;
-import ca.spottedleaf.dataconverter.minecraft.datatypes.MCTypeRegistry;
-import ca.spottedleaf.dataconverter.types.nbt.NBTMapType;
 import com.infernalsuite.asp.api.SlimeNMSBridge;
 import com.infernalsuite.asp.api.world.SlimeWorld;
 import com.infernalsuite.asp.api.world.SlimeWorldInstance;

--- a/aspaper-server/src/main/java/com/infernalsuite/asp/level/ReadOnlyDimensionDataStorage.java
+++ b/aspaper-server/src/main/java/com/infernalsuite/asp/level/ReadOnlyDimensionDataStorage.java
@@ -3,6 +3,7 @@ package com.infernalsuite.asp.level;
 import com.mojang.datafixers.DataFixer;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.world.level.saveddata.SavedData;
+import net.minecraft.world.level.saveddata.SavedDataType;
 import net.minecraft.world.level.storage.DimensionDataStorage;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -16,18 +17,13 @@ import java.util.concurrent.CompletableFuture;
  */
 public class ReadOnlyDimensionDataStorage extends DimensionDataStorage {
 
-    public ReadOnlyDimensionDataStorage(Path dataFolder, DataFixer fixerUpper, HolderLookup.Provider registries) {
-        super(dataFolder, fixerUpper, registries);
+    public ReadOnlyDimensionDataStorage(SavedData.Context ctx, Path dataFolder, DataFixer fixerUpper, HolderLookup.Provider registries) {
+        super(ctx, dataFolder, fixerUpper, registries);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public @Nullable <T extends SavedData> T get(SavedData.@NotNull Factory<T> factory, @NotNull String name) {
-        Optional<SavedData> optional = this.cache.get(name);
-        if(optional == null) {
-            return null;
-        }
-        return (T) optional.orElse(null);
+    public @Nullable <T extends SavedData> T get(SavedDataType<T> type) {
+        return (T) this.cache.get(type).orElse(null);
     }
 
     @Override

--- a/aspaper-server/src/main/java/com/infernalsuite/asp/level/ReadOnlyDimensionDataStorage.java
+++ b/aspaper-server/src/main/java/com/infernalsuite/asp/level/ReadOnlyDimensionDataStorage.java
@@ -23,7 +23,11 @@ public class ReadOnlyDimensionDataStorage extends DimensionDataStorage {
 
     @Override
     public @Nullable <T extends SavedData> T get(SavedDataType<T> type) {
-        return (T) this.cache.get(type).orElse(null);
+        Optional<SavedData> optional = this.cache.get(type);
+        if(optional == null) {
+            return null;
+        }
+        return (T) optional.orElse(null);
     }
 
     @Override

--- a/aspaper-server/src/main/java/com/infernalsuite/asp/level/SlimeInMemoryWorld.java
+++ b/aspaper-server/src/main/java/com/infernalsuite/asp/level/SlimeInMemoryWorld.java
@@ -252,7 +252,7 @@ public class SlimeInMemoryWorld implements SlimeWorld, SlimeWorldInstance {
         this.instance.getWorld().storeBukkitValues(nmsTag);
 
         // Bukkit stores the relevant tag as a tag with the key "BukkitValues" in the tag we supply to it
-        var adventureTag = Converter.convertTag(nmsTag.getCompound("BukkitValues"));
+        var adventureTag = Converter.convertTag(nmsTag.getCompoundOrEmpty("BukkitValues"));
         world.getExtraData().put("BukkitValues", adventureTag);
 
         return new SkeletonSlimeWorld(world.getName(),

--- a/aspaper-server/src/main/java/com/infernalsuite/asp/level/SlimeLevelInstance.java
+++ b/aspaper-server/src/main/java/com/infernalsuite/asp/level/SlimeLevelInstance.java
@@ -117,13 +117,14 @@ public class SlimeLevelInstance extends ServerLevel {
         slimeInstance.unload(chunk, slices);
     }
 
-    @Override
-    public void saveIncrementally(boolean doFull) {
-        if(doFull) {
-            //Avoid doing the internal save because it saves the level.dat into the temp folder. That causes pterodactyl users to have issues.
-            save();
-        }
-    }
+    //TODO(david): Figure out why thats missing in 1.21.5
+//    @Override
+//    public void saveIncrementally(boolean doFull) {
+//        if(doFull) {
+//            //Avoid doing the internal save because it saves the level.dat into the temp folder. That causes pterodactyl users to have issues.
+//            save();
+//        }
+//    }
 
     public Future<?> save() {
         AsyncCatcher.catchOp("SWM world save");

--- a/aspaper-server/src/main/java/com/infernalsuite/asp/level/SlimeLevelInstance.java
+++ b/aspaper-server/src/main/java/com/infernalsuite/asp/level/SlimeLevelInstance.java
@@ -117,7 +117,7 @@ public class SlimeLevelInstance extends ServerLevel {
         slimeInstance.unload(chunk, slices);
     }
 
-    //TODO(david): Figure out why thats missing in 1.21.5
+    //TODO(david): Re-add this once the following patch is applied: https://github.com/PaperMC/Paper/blob/update/1.21.5/paper-server/patches/unapplied/0024-Incremental-chunk-and-player-saving.patch
 //    @Override
 //    public void saveIncrementally(boolean doFull) {
 //        if(doFull) {

--- a/aspaper-server/src/main/java/com/infernalsuite/asp/level/SlimeLevelInstance.java
+++ b/aspaper-server/src/main/java/com/infernalsuite/asp/level/SlimeLevelInstance.java
@@ -117,14 +117,13 @@ public class SlimeLevelInstance extends ServerLevel {
         slimeInstance.unload(chunk, slices);
     }
 
-    //TODO(david): Re-add this once the following patch is applied: https://github.com/PaperMC/Paper/blob/update/1.21.5/paper-server/patches/unapplied/0024-Incremental-chunk-and-player-saving.patch
-//    @Override
-//    public void saveIncrementally(boolean doFull) {
-//        if(doFull) {
-//            //Avoid doing the internal save because it saves the level.dat into the temp folder. That causes pterodactyl users to have issues.
-//            save();
-//        }
-//    }
+    @Override
+    public void saveIncrementally(boolean doFull) {
+        if(doFull) {
+            //Avoid doing the internal save because it saves the level.dat into the temp folder. That causes pterodactyl users to have issues.
+            save();
+        }
+    }
 
     public Future<?> save() {
         AsyncCatcher.catchOp("SWM world save");

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ apiVersion=4.0.0-SNAPSHOT
 version=1.21.5-R0.1-SNAPSHOT
 
 mcVersion=1.21.5
-paperRef=35b466e315a447ef54162384d52bad6e1372bd36
+paperRef=5f0b82925e06c90400b4069631b15c8f2c47c76d
 
 org.gradle.caching=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 group=com.infernalsuite.asp
 apiVersion=4.0.0-SNAPSHOT
-version=1.21.4-R0.1-SNAPSHOT
+version=1.21.5-R0.1-SNAPSHOT
 
-mcVersion=1.21.4
-paperRef=6ea42025a49f232f47861c6ca943b0fc66b7effe
+mcVersion=1.21.5
+paperRef=ef0f0d101f97523b7b2df22fa90c04951bb48bca
 
 org.gradle.caching=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ apiVersion=4.0.0-SNAPSHOT
 version=1.21.5-R0.1-SNAPSHOT
 
 mcVersion=1.21.5
-paperRef=ef0f0d101f97523b7b2df22fa90c04951bb48bca
+paperRef=35b466e315a447ef54162384d52bad6e1372bd36
 
 org.gradle.caching=true
 org.gradle.parallel=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-adventure = "4.17.0"
+adventure = "4.20.0"
 annotations = "26.0.1"
 autoservice = "1.1.1"
 blossom = "2.1.0"


### PR DESCRIPTION
This PR is tracking the changes of 1.21.5

There are no changes except updating paper and temporarily disabling the loading of older worlds until DataConverter is back in paper. 

TODO:
- [ ] Wait for DataConverter to be back in Paper
- [x] Wait until #158 is merged into main