### PR TITLE
Properly bump API version

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -18,7 +18,7 @@ fun convertPlugin(plugin: Provider<PluginDependency>): String {
 dependencies {
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
     implementation(convertPlugin(libs.plugins.blossom))
-    implementation(convertPlugin(libs.plugins.gitprops))
+    implementation(convertPlugin(libs.plugins.indragit))
     implementation(convertPlugin(libs.plugins.profiles))
     implementation(convertPlugin(libs.plugins.kotlin.jvm))
     implementation(convertPlugin(libs.plugins.lombok))

--- a/buildSrc/src/main/kotlin/asp.base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/asp.base-conventions.gradle.kts
@@ -48,7 +48,7 @@ tasks {
     processResources {
         filteringCharset = Charsets.UTF_8.name()
         filesMatching(listOf("paper-plugin.yml", "version.txt")) {
-            expand("gitCommitId" to (the<IndraGitExtension>().commit()?.name ?: "unknown"))
+            expand("gitCommitId" to (project.the<IndraGitExtension>().commit()?.name ?: "unknown"))
         }
     }
 }

--- a/buildSrc/src/main/kotlin/asp.base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/asp.base-conventions.gradle.kts
@@ -1,6 +1,8 @@
+import net.kyori.indra.git.IndraGitExtension
+
 plugins {
     `java-library`
-    id("com.gorylenko.gradle-git-properties")
+    id("net.kyori.indra.git")
 }
 
 group = rootProject.providers.gradleProperty("group").get()
@@ -43,16 +45,10 @@ tasks {
             .tags("apiNote:a:API Note", "implSpec:a:Implementation Requirements", "implNote:a:Implementation Note")
     }
 
-    val git = withType<com.gorylenko.GenerateGitPropertiesTask> {
-        outputs.upToDateWhen { false }
-        gitProperties.extProperty = "git"
-    }.first()
-
     processResources {
         filteringCharset = Charsets.UTF_8.name()
-        dependsOn(git)
         filesMatching(listOf("paper-plugin.yml", "version.txt")) {
-            expand("gitCommitId" to git.generatedProperties["git.commit.id"])
+            expand("gitCommitId" to (the<IndraGitExtension>().commit()?.name ?: "unknown"))
         }
     }
 }

--- a/buildSrc/src/main/kotlin/asp.internal-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/asp.internal-conventions.gradle.kts
@@ -1,4 +1,8 @@
 import net.kyori.indra.git.IndraGitExtension
 import org.gradle.kotlin.dsl.the
 
+plugins {
+    id("net.kyori.indra.git")
+}
+
 version = "${rootProject.providers.gradleProperty("apiVersion").get()}-${the<IndraGitExtension>().commit()?.name ?: "SNAPSHOT"}"

--- a/buildSrc/src/main/kotlin/asp.internal-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/asp.internal-conventions.gradle.kts
@@ -1,0 +1,4 @@
+import net.kyori.indra.git.IndraGitExtension
+import org.gradle.kotlin.dsl.the
+
+version = "${rootProject.providers.gradleProperty("apiVersion").get()}-${the<IndraGitExtension>().commit()?.name ?: "SNAPSHOT"}"

--- a/buildSrc/src/main/kotlin/asp.publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/asp.publishing-conventions.gradle.kts
@@ -69,7 +69,13 @@ extensions.configure<ProfilesExtension>("profiles") {
                 repositories {
                     maven {
                         name = "infernalsuite"
-                        url = uri("https://repo.infernalsuite.com/repository/maven-snapshots/")
+
+                        url = if("${project.version}".endsWith("-SNAPSHOT")) {
+                            uri("https://repo.infernalsuite.com/repository/maven-snapshots/")
+                        } else {
+                            uri("https://repo.infernalsuite.com/repository/maven-releases/")
+                        }
+
                         credentials {
                             username = project.property("ISUsername") as String?
                             password = project.property("ISPassword") as String?

--- a/buildSrc/src/main/kotlin/asp.publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/asp.publishing-conventions.gradle.kts
@@ -71,16 +71,16 @@ extensions.configure<ProfilesExtension>("profiles") {
                         name = "infernalsuite"
                         url = uri("https://repo.infernalsuite.com/repository/maven-snapshots/")
                         credentials {
-//                            username = project.property("ISUsername") as String?
-//                            password = project.property("ISPassword") as String?
+                            username = project.property("ISUsername") as String?
+                            password = project.property("ISPassword") as String?
                         }
                     }
                 }
             }
-//            extensions.configure<SigningExtension>("signing") {
-//                useGpgCmd()
-//                sign(extensions.getByName<PublishingExtension>("publishing").publications["maven"])
-//            }
+            extensions.configure<SigningExtension>("signing") {
+                useGpgCmd()
+                sign(extensions.getByName<PublishingExtension>("publishing").publications["maven"])
+            }
         }
     }
 }

--- a/buildSrc/src/main/kotlin/asp.publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/asp.publishing-conventions.gradle.kts
@@ -71,16 +71,16 @@ extensions.configure<ProfilesExtension>("profiles") {
                         name = "infernalsuite"
                         url = uri("https://repo.infernalsuite.com/repository/maven-snapshots/")
                         credentials {
-                            username = project.property("ISUsername") as String?
-                            password = project.property("ISPassword") as String?
+//                            username = project.property("ISUsername") as String?
+//                            password = project.property("ISPassword") as String?
                         }
                     }
                 }
             }
-            extensions.configure<SigningExtension>("signing") {
-                useGpgCmd()
-                sign(extensions.getByName<PublishingExtension>("publishing").publications["maven"])
-            }
+//            extensions.configure<SigningExtension>("signing") {
+//                useGpgCmd()
+//                sign(extensions.getByName<PublishingExtension>("publishing").publications["maven"])
+//            }
         }
     }
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("asp.base-conventions")
+    id("asp.internal-conventions")
     id("asp.publishing-conventions")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,3 @@ org.gradle.parallel=true
 org.gradle.vfs.watch=false
 
 org.gradle.jvmargs=-Xmx10g
-publish=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.infernalsuite.asp
-apiVersion=4.0.0-SNAPSHOT
+apiVersion=4.0.0
 version=1.21.4-R0.1-SNAPSHOT
 
 mcVersion=1.21.4
@@ -10,3 +10,4 @@ org.gradle.parallel=true
 org.gradle.vfs.watch=false
 
 org.gradle.jvmargs=-Xmx10g
+publish=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ bstats = "3.1.0"
 cloud-core = "2.0.0"
 cloud-minecraft = "2.0.0-beta.10"
 configurate = "4.1.2"
-gradle-git-properties = "2.4.2"
+indra-git = "3.1.3"
 gradle-profiles = "0.54.0"
 hikari = "6.2.1"
 kotlin = "1.9.25"
@@ -23,7 +23,7 @@ zstd = "1.5.6-8"
 
 [plugins]
 blossom = { id = "net.kyori.blossom", version.ref = "blossom" }
-gitprops = { id = "com.gorylenko.gradle-git-properties", version.ref = "gradle-git-properties" }
+indragit = { id = "net.kyori.indra.git", version.ref = "indra-git" }
 profiles = { id = "org.kordamp.gradle.profiles", version.ref = "gradle-profiles" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 lombok = { id = "io.freefair.lombok", version.ref = "lombok-plugin" }


### PR DESCRIPTION
This PR changes the git library to indra as it is not strictly bound to a task, it bumps the API version from 4.0.0-SNAPSHOT to 4.0.0 and binds the core version to the current commit hash so it's easier to figure out which core corresponds with which server version