### PR TITLE
Register loaders to Bukkit services

### DIFF
--- a/plugin/src/main/java/com/infernalsuite/asp/plugin/SWPlugin.java
+++ b/plugin/src/main/java/com/infernalsuite/asp/plugin/SWPlugin.java
@@ -117,6 +117,8 @@ public class SWPlugin extends JavaPlugin {
             }
             Bukkit.unloadWorld(world.getName(), false); //Unload without saving as we have just saved (if not read only)
         }
+
+        Bukkit.getServicesManager().unregisterAll(this);
     }
 
     private List<String> loadWorlds() {


### PR DESCRIPTION
This allows other plugins to utilize the loaders that the SWM plugin creates. This would help prevent additional, redundant connections to the same data source.